### PR TITLE
Add footer disclaimer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,6 +9,7 @@
     {%- endcomment -%}
   </div>
   <!-- &copy; <script>document.write(new Date().getFullYear())</script> {{ site.title }} -->
+  <p class="footer-disclaimer">Any opinions I state on this site or on linked media or content are my own and are neither affiliated with nor endorsed by any employer, institution, person, or organization. Presentation of statements made by others (such as in page comments or in audio or video segments), references and/or links to such statements or content of others do not constitute my endorsement; these statements are solely affiliated with their respective authors. Content is provided for reference without any warranty as to its correctness or suitability for a given purpose.</p>
 </footer>
 
 {% if site.analytics.provider and page.analytics != false %}

--- a/css/footer.scss
+++ b/css/footer.scss
@@ -33,6 +33,16 @@ footer {
     }
   }
 
+  .footer-disclaimer {
+    margin-top: 20px;
+    font-size: 0.75em;
+    opacity: 0.6;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+    line-height: 1.5;
+  }
+
   a {
     color: $white !important;
     font-family: $sans;


### PR DESCRIPTION
## Summary

- Adds an opinions/affiliation disclaimer paragraph to the site footer
- Styles it with reduced font size (0.75em) and opacity (0.6) so it's visually de-emphasized, centered with a max-width of 800px

## Test plan

- [ ] Build the site and verify the disclaimer text appears at the bottom of every page
- [ ] Check that the styling renders correctly (small, muted text, centered)

https://claude.ai/code/session_01Q4tdKkudPQZKv8LCjSQFF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4tdKkudPQZKv8LCjSQFF9)_