### PR TITLE
Refactor card image markup and fix credit spacing

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -6,32 +6,26 @@
 
 <div class="card" data-size="{{ size }}">
   {% assign placeholder = include.placeholder | default: "images/placeholder.svg" | relative_url %}
+  {%- capture card_img -%}
+  {%- if include.image -%}
+  <img
+    src="{{ include.image | relative_url }}"
+    alt="{{ include.heading }}"
+    loading="lazy"
+    onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
+  >
+  {%- else -%}
+  <img src="{{ placeholder }}" alt="{{ include.heading }}" loading="lazy">
+  {%- endif -%}
+  {%- endcapture -%}
   <div class="card_image_wrap">
     {%- if include.link -%}
     <a href="{{ include.link | relative_url }}" class="card_image">
-      {%- if include.image -%}
-      <img
-        src="{{ include.image | relative_url }}"
-        alt="{{ include.heading }}"
-        loading="lazy"
-        onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
-      >
-      {%- else -%}
-      <img src="{{ placeholder }}" alt="{{ include.heading }}" loading="lazy">
-      {%- endif -%}
+      {{- card_img -}}
     </a>
     {%- else -%}
     <div class="card_image">
-      {%- if include.image -%}
-      <img
-        src="{{ include.image | relative_url }}"
-        alt="{{ include.heading }}"
-        loading="lazy"
-        onerror="this.src = '{{ placeholder }}'; this.onerror = null;"
-      >
-      {%- else -%}
-      <img src="{{ placeholder }}" alt="{{ include.heading }}" loading="lazy">
-      {%- endif -%}
+      {{- card_img -}}
     </div>
     {%- endif -%}
     {%- if include.image_credit -%}

--- a/css/card.scss
+++ b/css/card.scss
@@ -226,6 +226,10 @@
         height: 150px;
       }
 
+      .card_image_credit {
+        margin-bottom: 0;
+      }
+
       .card_text {
         width: 100%;
       }


### PR DESCRIPTION
## Summary
This PR refactors the card component to reduce code duplication and fixes spacing issues with image credits on smaller screens.

## Key Changes
- **DRY up image markup**: Extracted the conditional image rendering logic into a reusable `card_img` capture block to eliminate duplication between the linked and non-linked card image paths
- **Fix image credit spacing**: Added `margin-bottom: 0` to `.card_image_credit` in the small breakpoint styles to prevent excessive spacing on mobile devices

## Implementation Details
The image rendering logic (which handles both custom images with fallback error handling and placeholder images) was previously duplicated in two places within the card template. By capturing this markup once and reusing it via `{{- card_img -}}`, the template is now more maintainable and reduces the risk of inconsistencies between the two code paths.

The CSS fix ensures that image credits display properly without extra bottom margin on smaller screens where space is more constrained.

https://claude.ai/code/session_01EjPNAZpBYyoJ9bJCi1aaCW