### PR TITLE
Add project sidebar, member pages with inline projects/publications, and data tagging

### DIFF
--- a/_data/featured.yml
+++ b/_data/featured.yml
@@ -11,8 +11,8 @@ home:
       and explainable models that surface the why, not just the what.
     image: images/network.jpg
     alt: Connected nodes in a network diagram, suggesting how ideas and reasoning steps link in a learning system.
-    link: research
-    link_label: See the research
+    link: projects
+    link_label: See all projects
 
   - side: image-right
     eyebrow: BIOMEDICAL ML
@@ -24,5 +24,5 @@ home:
       not benchmarks for their own sake.
     image: images/laboratory.jpg
     alt: A research bench in a working laboratory, the scale at which biomedical machine learning lands.
-    link: research
-    link_label: See the research
+    link: projects
+    link_label: See all projects

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -2,24 +2,39 @@
 #
 # status: "active" | "completed"
 # type:   "research" | "software" | "student"
-# link:   Optional URL (demo, repo, publication, etc.)
 # image:  Optional thumbnail URL or path
+# research: Optional array of research-output IDs to show in the sidebar
 
-- title: "Mathforum AI: Mentir AI"
+- title: "AI in K-12 Math Education"
   status: active
   type: research
   image: /images/neural-network.svg
   description: >
-    An AI-powered math tutoring assistant built on the historic Mathforum
-    problem-thread archive. The project explores RAG (retrieval-augmented
-    generation) and fine-tuning strategies to provide pedagogically sound
-    feedback on student mathematical thinking, in collaboration with Jason
-    Silverman and the Gates Foundation.
+    Part of the Gates Foundation-funded MentirAI project, this research
+    builds an AI-powered math tutoring assistant on the historic Mathforum
+    problem-thread archive, exploring RAG (retrieval-augmented generation)
+    and fine-tuning strategies to provide pedagogically sound feedback on
+    student mathematical thinking, in collaboration with Jason Silverman.
+    The work extends into broader investigations of AI applications in
+    educational contexts — including generative AI, classroom integration,
+    and pedagogy — conducted with students across CS394 and the Honors
+    thesis sequence (CS491–CS492). This collaboration began in 2019.
   tags:
     - ai
     - education
     - mathematics
     - rag
+
+  team-contributors:
+    - william-m-mongan
+    - claire
+    - michael-c
+    - matthew-l
+    - renzhi
+    - tim
+  research:
+    - "manual:reinsburrow-2026-site"
+    - "manual:cummins-2026-cosa-rag"
 
 - title: "End-to-End Intelligent Cardiorespiratory Monitor"
   status: active
@@ -29,42 +44,115 @@
     A full-stack wearable system in collaboration with the Drexel Wireless Systems Lab for continuous, ambulatory cardiorespiratory
     monitoring. The project integrates signal acquisition, edge processing,
     and machine learning inference for real-time health monitoring outside
-    clinical settings.
+    clinical settings, and includes the IoT Sensor Framework (a HIPAA-compliant
+    platform for collecting data from IoT-based sensors including knitted smart
+    textiles) and the IoT Processing Framework (real-time and offline signal
+    processing and machine learning on sensor data), both developed with the
+    Drexel Wireless Systems Lab. Related student work includes multi-semester
+    research in RF-based biomedical signal acquisition and analysis using
+    wearable IoT devices (conducted across CS391 and CS394), independent study
+    in multi-sensor data fusion techniques for wearable and IoT applications
+    (conducted in CS392), and a machine learning pipeline for minute-level and
+    subject-level sleep apnea detection using ECG signals (presented at Ursinus
+    CoSA 2026 by Andrei Bogdan). We became involved in this research in 2013.
   tags:
     - machine learning
     - healthcare
     - wearables
     - iot
+    - sensing
+    - signal processing
+    - ecg
 
-- title: "RFID Antenna State Selection"
+  team-contributors:
+    - william-m-mongan
+    - andrei
+    - ian
+    - kevin-h
+  research:
+    - "manual:dissertation"
+    - "doi:10.1007/978-3-030-67494-6_4"
+    - "manual:electronics2022"
+    - "manual:compsac2021"
+    - "manual:bibe2020"
+    - "manual:spmb2019"
+    - "manual:compsac2019"
+    - "manual:tbhi2019"
+    - "manual:spmb2017"
+    - "manual:iotdi2017"
+    - "manual:rfid2017"
+    - "manual:spmb2016"
+    - "manual:smartcomp2016"
+    - "manual:bhi2016"
+    - "doi:10.5281/zenodo.3786933"
+    - "doi:10.5281/zenodo.3825126"
+    - "manual:bogdan-2026-cosa-sleep"
+
+- title: "RF Antenna State Selection for Localization and Tracking"
   status: active
   type: research
   image: /images/wireless-encrypted.svg
   description: >
-    Research into intelligent antenna state selection for RFID-based sensing in collaboration with the Drexel Wireless Systems Lab, targeting improved read range and accuracy in multi-tag environments.
+    Research into intelligent antenna state selection for RFID-based sensing
+    in collaboration with the Drexel Wireless Systems Lab, targeting improved
+    read range and accuracy in multi-tag environments. Related student research
+    includes RFID-based indoor localization, multi-tag tracking, and dynamic
+    radar sensing techniques, as well as research and educational module
+    development for software-defined radio (SDR) platforms in smart-grid
+    communication scenarios, conducted across CS392 and CS394. We became
+    involved in this research in 2016.
   tags:
     - rfid
     - wireless
     - sensing
+    - sdr
+    - infrastructure
+
+  team-contributors:
+    - william-m-mongan
+    - josh-b
+    - brenden
+    - ian
+    - josh-k
+    - kacey
+    - khoi
+    - matt-quigley
+    - nikolai
+    - zack
+    - breeze
+  research:
+    - "manual:sensors2023"
+    - "manual:access2020"
+    - "manual:sensors2020"
+    - "manual:wamicon2020"
+    - "manual:tbcs2016"
 
 - title: "Mentir AI: RAG vs. Fine-Tuning in Math Education"
   status: active
-  type: student
+  type: research
   image: /images/rag-schema.svg
   description: >
     Student research comparing retrieval-augmented generation and fine-tuning
     for building an AI math tutoring assistant on the Mathforum archive.
     Presented at Ursinus CoSA 2026. Developed by Michael Cummins, Matt Latta,
-    and Claire Shoemaker.
+    and Claire Shoemaker. This work began in 2025.
   tags:
     - ai
     - education
     - rag
 
+  team-contributors:
+    - william-m-mongan
+    - michael-c
+    - matthew-l
+    - claire
+  research:
+    - "manual:cummins-2026-cosa-rag"
+    - "manual:reinsburrow-2026-site"
+
 - title: "NVIZ: Neural Network Visualizer"
-  status: completed
+  status: active
   type: software
-  link: https://michaelcummins1.github.io/nviz/
   image: /images/nviz-sankey.png
   description: >
     An interactive, no-code neural network visualizer that lets users upload
@@ -72,313 +160,326 @@
     behavior through Sankey diagram visualizations — all in the browser.
     Developed by Ursinus students Kevin Hoffman and Michael Cummins.
     Source on <a href="https://github.com/michaelcummins1/nviz">GitHub</a>.
+    Related work includes tools for making machine learning model decisions
+    more interpretable and transparent (presented at Ursinus CoSA 2025 by
+    Michael Cummins), and independent studies developing methods to visualize
+    internal feature representations in trained neural networks. Conducted by
+    multiple students across CS391 and CS392. Development began in 2022.
   tags:
+    - ai
     - explainableai
     - visualization
     - education
 
+  team-contributors:
+    - william-m-mongan
+    - kevin-h
+    - michael-c
+  research:
+    - "url:https://digitalcommons.ursinus.edu/math_comp_pres/4/"
+    - "manual:cummins-2025-cosa-explainability"
+
 - title: "Ursinus WebIDE"
   status: completed
   type: software
-  link: https://www.billmongan.com/Ursinus-WebIDE/
   image: https://www.billmongan.com/Ursinus-WebIDE/images/graphicsScreenshot.png
   description: >
     A serverless, browser-based development environment for student practice
     and rapid instructor exercise development, supporting multiple languages
-    with no setup required. Developed with Christopher Tralie.
+    with no setup required. Developed with Christopher Tralie. Development
+    took place from 2020 to 2026.
   tags:
     - cs education
     - ide
     - webide
 
-- title: "IoT Sensor Framework"
-  status: completed
-  type: software
-  link: https://github.com/drexelwireless/iot-sensor-framework
-  image: http://www.billmongan.com/files/media/software-iotframework/simbabyandpregnancy.jpg
-  description: >
-    A platform to collect data from IoT-based sensors — including knitted
-    smart textiles — for HIPAA-compliant processing and research. Developed
-    with the Drexel Wireless Systems Lab.
-  tags:
-    - iot
-    - healthcare
-    - wearables
-
-- title: "IoT Processing Framework"
-  status: completed
-  type: software
-  link: https://github.com/drexelwireless/iot-processing-framework
-  image: http://www.billmongan.com/files/media/software-iotframework/simbaby.jpg
-  description: >
-    Integrates with the IoT Sensor Framework to provide real-time or offline
-    signal processing and machine learning on data collected by the sensor
-    framework. Developed with the Drexel Wireless Systems Lab.
-  tags:
-    - iot
-    - machine learning
-    - signal processing
-
-- title: "Sleep Apnea Detection via ECG"
-  status: completed
-  type: student
-  image: /images/ecg-trace.svg
-  description: >
-    A machine learning pipeline for minute-level and subject-level sleep apnea
-    detection using ECG signals. Presented at Ursinus CoSA 2026. Developed by
-    Andrei Bogdan.
-  tags:
-    - machine learning
-    - healthcare
-    - ecg
-
-- title: "AI Explainability Tools"
-  status: completed
-  type: student
-  image: /images/decision-tree.svg
-  description: >
-    Tools for making machine learning model decisions more interpretable and
-    transparent. Presented at Ursinus CoSA 2025. Developed by Michael Cummins.
-  tags:
-    - explainableai
-    - ai
+  team-contributors:
+    - william-m-mongan
+  research:
+    - "doi:10.1145/3770761.3777114"
 
 - title: "Grizzly Guide to Wealth (GGTW)"
   status: completed
-  type: student
-  link: https://digitalcommons.ursinus.edu/math_comp_pres/9/
+  type: research
   image: /images/candlestick-chart.svg
   description: >
     A suite of financial literacy and planning tools developed for the Grizzly
     Guide to Wealth platform. Presented at Ursinus CoSA 2025. Developed by
-    Eugene Thompson and George Psaradakis.
+    Eugene Thompson and George Psaradakis. Related independent study work
+    developed FinLitKit, an open financial literacy toolkit for educational
+    and personal finance use, conducted in CS392. This work was conducted
+    from 2024 to 2025.
   tags:
     - financial
     - tools
 
+  team-contributors:
+    - william-m-mongan
+    - eugene-t
+  research:
+    - "manual:thompson-2025-cosa-ggtw"
+
 - title: "UCPlaces: Campus Orientation App"
   status: completed
-  type: student
+  type: research
   image: /images/map-pin.svg
   description: >
     A mobile campus orientation app using ArcGIS to help new students navigate
     Ursinus College. Presented at Ursinus CoSA 2023. Developed by Arthur Artene
-    and Tristan Ashcroft.
+    and Tristan Ashcroft. This work was conducted from 2022 to 2023.
   tags:
     - gis
     - mobile
 
+  team-contributors:
+    - william-m-mongan
+    - arthur
+  research:
+    - "manual:artene-2023-cosa-ucplaces"
+
 - title: "RF IoT Security Layer"
   status: completed
-  type: student
+  type: research
   image: /images/wireless-encrypted.svg
   description: >
     A radio-frequency security layer for IoT sensor networks, adding
     authentication and encryption at the physical layer. Presented at
-    Ursinus CoSA 2023. Developed by Jonas Ling.
+    Ursinus CoSA 2023. Developed by Jonas Ling. Related independent study
+    explored side-channel electromagnetic signatures for hardware-level
+    malware detection, conducted in CS391. This work was conducted from
+    2021 to 2023.
   tags:
     - iot
     - security
+    - cybersecurity
+    - machine learning
+
+  team-contributors:
+    - william-m-mongan
+    - jonas
+  research:
+    - "manual:ling-2023-cosa-iot"
 
 - title: "Automated Moon Crater Detection"
   status: completed
-  type: student
+  type: research
   image: /images/moon-crater.svg
   description: >
     Exploring algorithmic and neural network approaches to automatically
     detect and catalog craters on the lunar surface from LRO imagery.
-    Presented at Ursinus CoSA 2023. Developed by Dylan Melby.
+    Presented at Ursinus CoSA 2023. Developed by Dylan Melby. Related
+    independent study applied deep learning techniques to astrophysical
+    image and data analysis more broadly, conducted in CS391. This work
+    was conducted from 2020 to 2023.
   tags:
     - machine learning
     - computer vision
+    - astrophysics
+
+  team-contributors:
+    - william-m-mongan
+    - dylan
+    - will
+  research:
+    - "manual:melby-2023-cosa-moon"
 
 - title: "Interactive AI Theater Presentation"
   status: active
-  type: student
+  type: research
   image: /images/neural-network.svg
   description: >
     An AI-driven interactive theater performance exploring human-machine
     collaboration in live performance art. Presented at Ursinus CoSA 2026.
-    Developed by Levi Fritz and Shannon Zura.
+    Developed by Levi Fritz and Shannon Zura. This work began in 2025.
   tags:
     - ai
     - performance art
     - interactive
 
-- title: "AI in Teaching and Learning"
+  team-contributors:
+    - william-m-mongan
+    - levi-f
+  research:
+    - "manual:fritz-2026-cosa-theater"
+
+
+- title: "Pennsylvania Statewide Computing Education Data Systems (NSF ECEP)"
   status: active
-  type: student
+  type: research
+  image: /images/map-pin.svg
+  description: >
+    An internship project developing statewide data infrastructure for
+    Pennsylvania to broaden access to K–12 computing education, in support
+    of the NSF Expanding Computing Education Pathways (ECEP) Alliance.
+    Conducted by one student (CS382). This work began in 2025.
+  tags:
+    - cs education
+    - data systems
+    - broadening participation
+
+  team-contributors:
+    - jonathan
+    - william-m-mongan
+
+- title: "Institutional Tonality Analysis for At-Risk Student Re-Engagement"
+  status: active
+  type: research
   image: /images/neural-network.svg
   description: >
-    Honors and research independent studies investigating AI applications
-    in educational contexts, including generative AI, classroom integration,
-    and pedagogy. Conducted by four students across CS394 and the Honors
-    thesis sequence (CS491–CS492).
+    An internship project analyzing institutional communication data to
+    identify trends in linguistic tonality and their relationship to academic
+    re-engagement among at-risk students. Conducted by one student (CS382).
+    This work began in 2025.
   tags:
-    - ai
+    - data analysis
     - education
+    - student success
+    - nlp
+
+  team-contributors:
+    - william-m-mongan
+    - izayah-c
 
 - title: "AI-Based Wi-Fi Penetration Tool"
-  status: completed
-  type: student
+  status: active
+  type: research
   image: /images/wireless-encrypted.svg
   description: >
     Honors independent study designing an AI-assisted tool for automated
-    Wi-Fi security assessment and penetration testing. Conducted in the
-    Honors thesis sequence (CS491–CS492).
+    Wi-Fi security assessment and penetration testing, using the Pwnagotchi
+    software framework to explore and mitigate Wi-Fi vulnerability exploits.
+    Conducted in the Honors thesis sequence (CS491–CS492). This work began
+    in 2025.
   tags:
     - ai
     - cybersecurity
     - wireless
 
+  team-contributors:
+    - william-m-mongan
+    - emily
+
 - title: "Human Pose Estimation through WiFi"
   status: completed
-  type: student
+  type: research
   image: /images/wireless-encrypted.svg
   description: >
     Research independent studies using RF signal analysis and machine
     learning to estimate human body pose without cameras. Conducted by
-    two students (CS394).
+    two students (CS394). This work was conducted from 2023 to 2024.
   tags:
     - machine learning
     - wireless
     - sensing
 
-- title: "RFID Localization and Tracking"
-  status: completed
-  type: student
-  image: /images/wireless-encrypted.svg
-  description: >
-    Research independent studies in RFID-based indoor localization,
-    multi-tag tracking, and dynamic radar sensing techniques. Conducted
-    by four students across CS394.
-  tags:
-    - rfid
-    - wireless
-    - sensing
+  team-contributors:
+    - william-m-mongan
+    - kacey
 
-- title: "RF Biomedical Analysis via Wearable IoT"
-  status: completed
-  type: student
-  image: /images/ecg-trace.svg
-  description: >
-    Multi-semester research in RF-based biomedical signal acquisition
-    and analysis using wearable IoT sensor devices. Conducted by four
-    students across CS391 and CS394.
-  tags:
-    - healthcare
-    - wearables
-    - iot
 
-- title: "Grid Software Defined Radios"
+- title: "Natural Language Processing to Parse the Taino Language"
   status: completed
-  type: student
-  image: /images/wireless-encrypted.svg
-  description: >
-    Research and educational module development for software-defined
-    radio (SDR) platforms in smart-grid communication scenarios.
-    Conducted by multiple students across CS392 and CS394.
-  tags:
-    - wireless
-    - sdr
-    - infrastructure
-
-- title: "AI Feature Visualization"
-  status: completed
-  type: student
+  type: research
   image: /images/neural-network.svg
   description: >
-    Research independent studies developing methods to visualize
-    internal feature representations in trained neural networks,
-    connecting to broader explainable AI themes. Conducted by
-    multiple students across CS391 and CS392.
-  tags:
-    - ai
-    - explainableai
-    - visualization
-
-- title: "Natural Language Processing Research"
-  status: completed
-  type: student
-  image: /images/neural-network.svg
-  description: >
-    Research independent study in natural language processing
-    techniques and applications, including retrieval-augmented
-    approaches. Conducted by three students (CS394).
+    Research independent study applying natural language processing
+    techniques — including retrieval-augmented approaches — to parse and
+    analyze the Taino language. Conducted by three students (CS394). This
+    work was conducted from 2023 to 2024.
   tags:
     - ai
     - nlp
+    - linguistics
 
-- title: "FinLitKit: Financial Literacy Toolkit"
-  status: completed
-  type: student
-  image: /images/candlestick-chart.svg
-  description: >
-    Independent study developing an open financial literacy
-    toolkit for educational and personal finance use. Conducted
-    in CS392.
-  tags:
-    - financial
-    - tools
-
-- title: "Sensor Fusion Research"
-  status: completed
-  type: student
-  image: /images/ecg-trace.svg
-  description: >
-    Research independent study in multi-sensor data fusion
-    techniques for wearable and IoT applications. Conducted
-    by two students (CS392).
-  tags:
-    - iot
-    - sensing
-    - machine learning
-
-- title: "Malware Detection via Electromagnetic Response"
-  status: completed
-  type: student
-  image: /images/wireless-encrypted.svg
-  description: >
-    Research independent study exploring side-channel
-    electromagnetic signatures for hardware-level malware
-    detection. Conducted in CS391.
-  tags:
-    - cybersecurity
-    - machine learning
+  team-contributors:
+    - william-m-mongan
+    - audrey
+    - mold
+    - matthew-a
 
 - title: "Virtual Museum Environments"
   status: completed
-  type: student
+  type: research
   image: /images/map-pin.svg
   description: >
     Research independent study in virtual reality museum
     environment design and interactive digital exhibit
-    development. Conducted in CS391.
+    development. Conducted in CS391. This work was conducted from 2023
+    to 2024.
   tags:
     - vr
     - education
 
+  team-contributors:
+    - william-m-mongan
+    - josh-f
+
 - title: "Wireless Emergency Communications"
-  status: completed
-  type: student
+  status: active
+  type: research
   image: /images/wireless-encrypted.svg
   description: >
-    Independent studies in reliable RF-based emergency
-    communication systems and protocols, including amateur
-    radio integration. Conducted across CS392 and CS394.
+    Independent studies in reliable RF-based emergency communication systems
+    and protocols, including amateur radio integration, conducted across CS392
+    and CS394. Work is conducted in collaboration with the Montgomery County
+    ARES/RACES group and the Jim Fisher Memorial Digital Network Association.
+    This work began in 2024.
   tags:
     - wireless
     - communications
     - rf
+    - public safety
 
-- title: "Deep Learning in Astrophysics"
-  status: completed
-  type: student
-  image: /images/moon-crater.svg
+  team-contributors:
+    - william-m-mongan
+    - owen
+
+- title: "Pixel Pandemonium"
+  status: active
+  type: research
+  image: https://img.youtube.com/vi/72TPC2bYaLk/hqdefault.jpg
   description: >
-    Research independent study applying deep learning
-    techniques to astrophysical image and data analysis.
-    Conducted in CS391.
+    An "unplugged" interactive activity for teaching computer science
+    fundamentals through pixel-based visual demonstrations — no computer
+    required. Participants fill in grids to recreate images and animations,
+    building intuition for how digital graphics, encoding, and algorithms
+    work. The activity has been presented at venues including CSTA,
+    CS4Philly, CS4AllPA, the Philadelphia Science Festival, and Pixar,
+    and can be explored at the
+    <a href="https://www.billmongan.com/Ursinus-CS173/DrawingCanvas/Replay">Pixel Pandemonium drawing canvas</a>.
+    Developed in part through independent research projects by two students
+    in CS394. This work began in 2022.
   tags:
-    - machine learning
-    - astrophysics
+    - cs education
+    - visualization
+    - outreach
+    - pixel graphics
+
+  team-contributors:
+    - william-m-mongan
+    - tyler
+    - jaheim
+  research:
+    - "manual:pandemonium-2019-sigcse"
+
+- title: "Facilitating Rapid Emergency Response via Graph Optimization Algorithms"
+  status: active
+  type: research
+  image: /images/fire-hydrant.svg
+  description: >
+    Research applying graph pathfinding algorithms and network flow analysis
+    to GIS data to optimize emergency fire response. The project identifies
+    the optimal fire hydrants to use given a fire location, and determines
+    which roads to close to protect equipment and personnel while maintaining
+    driver visibility.
+
+  tags:
+    - gis
+    - graph algorithms
+    - optimization
+    - public safety
+
+  team-contributors:
+    - william-m-mongan
+    - aleni
+

--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -1,53 +1,53 @@
 # List your research papers here. The "build research" Python script takes this
 # file and uses Manubot to generate a fully-cited "output research" file, which
 # is then read by the research list component.
- 
+
 # NOTES:
- 
+
 # Using the research list component, papers will be displayed in order of and
 # grouped by date, regardless of how they are listed here.
- 
+
 # Any property that Manubot returns can be manually overridden by putting it
 # here, such as "date", "publisher", etc. Use the output file as a reference
 # for the expected format (eg dates should be YYYY-MM-DD).
- 
+
 # If a paper is already in the output file (matched by id), that existing
 # citation data will be used instead of calling Manubot again. To clear this
 # "cache", remove that output entry, or simply delete the whole output file.
- 
+
 # PARAMETERS:
- 
+
 # id:
 # An identifier string that Manubot can understand and cite. Also used to
 # determine if a paper already exists in the output.
- 
+
 # image:
 # Url to a striking image. Use a figure from your paper, or if there are none,
 # use a journal logo or issue cover.
- 
+
 # tags:
 # A list of key topics/themes of your paper. Aim for 2 to 5. look at other
 # papers and try to use similar tags.
- 
+
 # repo:
 # A GitHub repo to automatically fetch tags (aka "topics") from.
- 
+
 # extra-links:
 # A list of additional links - beyond the main paper link that Manubot returns
 # - that will show under your paper citation.
- 
+
 # type:
 # Determines link icon and default text. Look in "/_includes/paper-links.html"
 # to see what unique types can be specified.
- 
+
 # text:
 # Text to show next to icon. If not specified, defaults to some text that
 # matches type (see "type")
- 
+
 # link:
 # Url to link to. If not specified, defaults to the url that Manubot returns for
 # the citation.
- 
+
 # Examples:
 #- id: doi:10.1101/2020.11.06.371963
 #  thumbnail: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
@@ -63,7 +63,6 @@
 #      link: https://doi.org/10.1101/142760
 #    - type: source
 #      link: http://github.com/greenelab/deep-review
- 
 - id: doi:10.5281/zenodo.3786933
   type: source
   image: http://www.billmongan.com/files/media/software-iotframework/simbabyandpregnancy.jpg
@@ -71,7 +70,10 @@
   tags:
     - iot
   cluster: systems-iot-cv
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
 - id: doi:10.5281/zenodo.3825126
   type: source
   link: "https://github.com/drexelwireless/iot-processing-framework"
@@ -79,7 +81,10 @@
   tags:
     - iot
   cluster: systems-iot-cv
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
 - id: url:https://digitalcommons.ursinus.edu/math_comp_pres/4/
   title: "NVIZ: Unraveling Neural Networks Through Visualization"
   authors:
@@ -95,7 +100,12 @@
     - visualization
     - cosa
   cluster: explainable-ai
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - kevin-h
+
 - id: doi:10.1145/3770761.3777114
   title: "The Ursinus WebIDE: A Serverless Browser-Based Development Environment for Student Practice and Rapid Instructor Exercise Development"
   authors:
@@ -110,7 +120,11 @@
     - ide
     - webide
   cluster: teaching-learning
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
 - id: manual:reinsburrow-2026-site
   title: "Instructional Judgment, Not Just Correctness: Evaluating AI-Generated Feedback on Student Mathematical Thinking"
   authors:
@@ -133,7 +147,13 @@
     - education
     - mathematics
   cluster: teaching-learning
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - michael-c
+    - matthew-l
+
 - id: manual:fritz-2026-cosa-theater
   title: "Interactive AI Theater Presentation"
   authors:
@@ -150,7 +170,11 @@
     - interactive
     - cosa
   cluster: teaching-learning
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
 - id: manual:cummins-2026-cosa-rag
   title: "RAG vs. Fine-Tuning in Math Education: Developing and Validating Mentir AI"
   authors:
@@ -168,7 +192,14 @@
     - rag
     - cosa
   cluster: teaching-learning
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - michael-c
+    - matthew-l
+    - claire
+
 - id: manual:bogdan-2026-cosa-sleep
   title: "Minute and Subject-Level Sleep Apnea Detection Using an ECG-Based Machine Learning Pipeline"
   authors:
@@ -184,7 +215,12 @@
     - ecg
     - cosa
   cluster: biomedical-ml
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - andrei
+
 - id: manual:cummins-2025-cosa-explainability
   title: "Developing Tools for AI Explainability"
   authors:
@@ -199,7 +235,12 @@
     - ai
     - cosa
   cluster: explainable-ai
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - michael-c
+
 - id: manual:thompson-2025-cosa-ggtw
   title: "Financial Tools for the Grizzly Guide to Wealth (GGTW)"
   authors:
@@ -216,7 +257,11 @@
     - tools
     - cosa
   cluster: teaching-learning
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
 - id: manual:artene-2023-cosa-ucplaces
   title: "UCPlaces: Campus Orientation App Using ArcGIS"
   authors:
@@ -232,7 +277,12 @@
     - mobile
     - cosa
   cluster: systems-iot-cv
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - arthur
+
 - id: manual:ling-2023-cosa-iot
   title: "RF IoT Security Layer"
   authors:
@@ -247,7 +297,12 @@
     - security
     - cosa
   cluster: systems-iot-cv
- 
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+    - jonas
+
 - id: manual:melby-2023-cosa-moon
   title: "Automated Moon Crater Detection: Exploring Algorithmic and Neural Network Approaches"
   authors:
@@ -262,3 +317,751 @@
     - computer vision
     - cosa
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+
+# New entries from billmongan.com/publications (visible: false until reviewed)
+  team-contributors:
+    - william-m-mongan
+    - dylan
+
+- id: manual:dissertation
+  title: "Predictive Analytics on Real-Time Biofeedback for Actionable Classification of Activity State"
+  authors:
+    - William M. Mongan
+  publisher: Drexel University
+  date: '2018-01-01'
+  type: thesis
+  link: https://www.billmongan.com/publication/dissertation
+  image: /images/ecg-trace.svg
+  tags:
+    - machine learning
+    - healthcare
+    - rfid
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:msthesis
+  title: "A Service-Based Web Portal for Integrated Reverse Engineering and Program Comprehension"
+  authors:
+    - William M. Mongan
+  publisher: Drexel University
+  date: '2008-01-01'
+  type: thesis
+  link: https://www.billmongan.com/publication/msthesis
+  image: /images/neural-network.svg
+  tags:
+    - software engineering
+    - web
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: doi:10.1007/978-3-030-67494-6_4
+  title: "Wearable Smart Garment Devices for Passive Biomedical Monitoring"
+  authors:
+    - Chelsea Amanatides
+    - Stephen Hansen
+    - Ariana S. Levitt
+    - Yuqiao Liu
+    - Patrick O-Neill
+    - Damiano Patron
+    - Robert Ross
+    - Daniel Schwartz
+    - Jesse Stover
+    - Md Abu Saleh Tajin
+    - Genevieve Dion
+    - Adam K. Fontecchio
+    - Vasil Pano
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: "Biomedical Signal Processing: Innovation and Applications"
+  date: '2021-04-01'
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2021
+  image: /images/ecg-trace.svg
+  tags:
+    - wearables
+    - healthcare
+    - iot
+    - rfid
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:aose2011
+  title: "A Methodology for Developing an Agent Systems Reference Architecture"
+  authors:
+    - Duc N. Nguyen
+    - Kyle Usbeck
+    - William M. Mongan
+    - Christopher T. Cannon
+    - Robert N. Lass
+    - Jeff Salvage
+    - William C. Regli
+    - Israel Mayk
+    - Todd Urness
+  publisher: "Agent-Oriented Software Engineering XI"
+  date: '2011-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/aose2011
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:sensors2023
+  title: "Passive UHF RFID-based Real-Time Intravenous Fluid Level Sensor"
+  authors:
+    - Md Abu Saleh Tajin
+    - Md Shakir Hossain
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: IEEE Sensors Journal
+  date: '2023-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/sensors2023
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - healthcare
+    - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:electronics2022
+  title: "Energy-Efficient Respiratory Anomaly Detection in Premature Newborn Infants"
+  authors:
+    - Ankita Paul
+    - Md. A.S. Tajin
+    - Anup Das
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: "MDPI Electronics Journal - Neuromorphic Sensing and Computing Systems"
+  date: '2022-03-01'
+  type: paper
+  link: https://www.billmongan.com/publication/electronics2022
+  image: /images/ecg-trace.svg
+  tags:
+    - machine learning
+    - healthcare
+    - rfid
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:access2020
+  title: "UHF RFID Channel Emulation Testbed for Wireless IoT Systems"
+  authors:
+    - Md Abu Saleh Tajin
+    - Marko Jacovic
+    - Genevieve Dion
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: IEEE Access Journal
+  date: '2021-05-01'
+  type: paper
+  link: https://www.billmongan.com/publication/access2020
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - iot
+    - wireless
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:sensors2020
+  title: "Passive RFID-based Diaper Moisture Sensor"
+  authors:
+    - Md Abu Saleh Tajin
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: IEEE Sensors Journal
+  date: '2020-10-01'
+  type: paper
+  link: https://www.billmongan.com/publication/sensors2020
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - healthcare
+    - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:tbhi2019
+  title: "Ensemble Learning Approach via Kalman Filtering for a Passive Wearable Respiratory Monitor"
+  authors:
+    - Sayandeep Acharya
+    - William M. Mongan
+    - Ilhaan Rasheed
+    - Yuqiao Liu
+    - Endla Anday
+    - Genevieve Dion
+    - Adam Fontecchio
+    - Timothy Kurzweg
+    - Kapil R. Dandekar
+  publisher: IEEE Transactions on Biomedical and Health Informatics
+  date: '2019-05-01'
+  type: paper
+  link: https://www.billmongan.com/publication/tbhi2019
+  image: /images/ecg-trace.svg
+  tags:
+    - machine learning
+    - healthcare
+    - wearables
+    - rfid
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:tbcs2016
+  title: "On the Use of Knitted Antennas and Inductively Coupled RFID Tags for Wearable Applications"
+  authors:
+    - Damiano Patron
+    - William Mongan
+    - Timothy Kurzweg
+    - Adam Fontecchio
+    - Genevieve Dion
+    - Endla Anday
+    - Kapil R. Dandekar
+  publisher: IEEE Transactions on Biomedical Circuits and Systems
+  date: '2016-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/tbcs2016
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - wearables
+    - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:thms2013
+  title: "Development and Specification of a Reference Architecture for Agent-Based Systems"
+  authors:
+    - William Regli
+    - Israel Mayk
+    - Christopher Cannon
+    - Joseph Kopena
+    - Robert Lass
+    - William M. Mongan
+  publisher: IEEE Transactions on Human Machine Systems
+  date: '2013-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/thms2013
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:smc2009
+  title: "Development and Specification of a Reference Model for Agent-Based Systems"
+  authors:
+    - William Regli
+    - Israel Mayk
+    - Christopher J. Dugan
+    - Joseph B. Kopena
+    - Robert N. Lass
+    - Pragnesh Jay Modi
+    - William M. Mongan
+    - Jeff K. Salvage
+    - Evan A. Sultanik
+  publisher: IEEE Transactions on Systems Man and Cybernetics
+  date: '2009-09-01'
+  type: paper
+  link: https://www.billmongan.com/publication/smc2009
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:compsac2021
+  title: "An Adaptively Parameterized Algorithm Estimating Respiratory Rate from a Passive Wearable RFID Smart Garment"
+  authors:
+    - Robert Ross
+    - William M. Mongan
+    - Patrick O-Neill
+    - Ilhaan Rasheed
+    - Adam Fontecchio
+    - Genevieve Dion
+    - Kapil R. Dandekar
+  publisher: "IEEE Conference on Computers, Software, and Applications (COMPSAC)"
+  date: '2021-07-01'
+  type: paper
+  link: https://www.billmongan.com/publication/compsac2021
+  image: /images/ecg-trace.svg
+  tags:
+    - rfid
+    - healthcare
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:wamicon2020
+  title: "Channel Emulation for the Characterization of Wearable RFID Antennas"
+  authors:
+    - Md Abu Saleh Tajin
+    - Marko Jacovic
+    - Xaime Rivas Rey
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: "IEEE Wireless and Microwave Technology Conference (WAMICON)"
+  date: '2021-04-01'
+  type: paper
+  link: https://www.billmongan.com/publication/wamicon2020
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - wireless
+    - wearables
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:bibe2020
+  title: "Fusion Learning on Multiple-Tag RFID Measurements for Respiratory Rate Monitoring"
+  authors:
+    - Stephen Hansen
+    - Daniel Schwartz
+    - Jesse Stover
+    - Md Abu Saleh Tajin
+    - William M. Mongan
+    - Kapil R. Dandekar
+  publisher: "IEEE International Conference on Bioinformatics and Biomedical Engineering (BIBE)"
+  date: '2020-10-01'
+  type: paper
+  link: https://www.billmongan.com/publication/bibe2020
+  image: /images/ecg-trace.svg
+  tags:
+    - machine learning
+    - rfid
+    - healthcare
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:spmb2019
+  title: "An Adaptive Search Algorithm for Detecting Respiratory Artifacts Using a Wireless Passive Wearable Device"
+  authors:
+    - Patrick O-Neill
+    - William M. Mongan
+    - Robert Ross
+    - Sayandeep Acharya
+    - Adam K. Fontecchio
+    - Kapil R. Dandekar
+  publisher: "IEEE Signal Processing in Medicine and Biology"
+  date: '2019-12-01'
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2019
+  image: /images/ecg-trace.svg
+  tags:
+    - rfid
+    - healthcare
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:compsac2019
+  title: "Activity Segmentation Using Wearable Sensors for DVT/PE Risk Detection"
+  authors:
+    - Austin Gentry
+    - William M. Mongan
+    - Brent Lee
+    - Owen Montgomery
+    - Kapil Dandekar
+  publisher: "The First IEEE International Workshop on Integrated Smart Healthcare (WISH 2019) at IEEE COMPSAC"
+  date: '2019-07-01'
+  type: paper
+  link: https://www.billmongan.com/publication/compsac2019
+  image: /images/ecg-trace.svg
+  tags:
+    - machine learning
+    - healthcare
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:spmb2017
+  title: "Data Fusion of Single-Tag RFID Measurements for Respiratory Rate Monitoring"
+  authors:
+    - William M. Mongan
+    - Robert Ross
+    - Ilhaan Rasheed
+    - Yuqiao Liu
+    - Khyati Ved
+    - Endla Anday
+    - Kapil Dandekar
+    - Genevieve Dion
+    - Timothy Kurzweg
+    - Adam Fontecchio
+  publisher: "IEEE Signal Processing in Medicine and Biology (SPMB)"
+  date: '2017-12-01'
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2017
+  image: /images/ecg-trace.svg
+  tags:
+    - rfid
+    - healthcare
+    - signal processing
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:rfid2017
+  title: "On Implementing an Unconventional Infant Vital Signs Monitor with Passive RFID Tags"
+  authors:
+    - Shrenik A. Vora
+    - William M. Mongan
+    - Endla K. Anday
+    - Kapil R. Dandekar
+    - Genevieve Dion
+    - Adam K. Fontecchio
+    - Timothy P. Kurzweg
+  publisher: "IEEE International Conference on RFID"
+  date: '2017-05-01'
+  type: paper
+  link: https://www.billmongan.com/publication/rfid2017
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - healthcare
+    - wearables
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:iotdi2017
+  title: "On the Use of Radio Frequency Identification for Continuous Biomedical Monitoring"
+  authors:
+    - William Mongan
+    - Ilhaan Rasheed
+    - Khyati Ved
+    - Shrenik Vora
+    - Kapil Dandekar
+    - Genevieve Dion
+    - Timothy Kurzweg
+    - Adam Fontecchio
+  publisher: "ACM/IEEE International Conference on Internet-of-Things Design and Implementation (IoTDI)"
+  date: '2017-04-01'
+  type: paper
+  link: https://www.billmongan.com/publication/iotdi2017
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - healthcare
+    - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:spmb2016
+  title: "Real-Time Detection of Apnea via Signal Processing of Time-Series Properties of RFID-Based Smart Garments"
+  authors:
+    - William M. Mongan
+    - Ilhaan Rasheed
+    - Khyati Ved
+    - Ariana Levitt
+    - Endla Anday
+    - Kapil Dandekar
+    - Genevieve Dion
+    - Timothy Kurzweg
+    - Adam Fontecchio
+  publisher: "IEEE Signal Processing in Medicine and Biology (SPMB)"
+  date: '2016-12-01'
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2016
+  image: /images/ecg-trace.svg
+  tags:
+    - rfid
+    - healthcare
+    - signal processing
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:smartcomp2016
+  title: "A Multi-Disciplinary Framework for Continuous Biomedical Monitoring Using Low-Power Passive RFID-based Wireless Wearable Sensors"
+  authors:
+    - William Mongan
+    - Endla Anday
+    - Genevieve Dion
+    - Adam Fontecchio
+    - Tim Kurzweg
+    - Kelly Joyce
+    - Yuqiao Liu
+    - Owen Montgomery
+    - Ilhaan Rasheed
+    - Cem Sahin
+    - Shrenik Vora
+    - Kapil Dandekar
+  publisher: "Proceedings of the IEEE Smart Systems Workshop"
+  date: '2016-05-01'
+  type: paper
+  link: https://www.billmongan.com/publication/smartcomp2016
+  image: /images/wireless-encrypted.svg
+  tags:
+    - rfid
+    - healthcare
+    - wearables
+    - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:bhi2016
+  title: "Wireless Heart and Respiration Monitoring for Infants through Passive RFID Tags"
+  authors:
+    - Shrenik Vora
+    - William Mongan
+    - Kapil Dandekar
+    - Adam Fontecchio
+    - Tim Kurzweg
+  publisher: "IEEE International Conference on Biomedical and Health Informatics (BHI)"
+  date: '2016-02-01'
+  type: paper
+  link: https://www.billmongan.com/publication/bhi2016
+  image: /images/ecg-trace.svg
+  tags:
+    - rfid
+    - healthcare
+    - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:aose2010
+  title: "Developing an Agent Systems Reference Architecture"
+  authors:
+    - Duc N. Nguyen
+    - Robert N. Lass
+    - Kyle Usbeck
+    - William M. Mongan
+    - Christopher T. Cannon
+    - William C. Regli
+    - Israel Mayk
+    - Todd Urness
+  publisher: "Proceedings of the 11th International Workshop on Agent Oriented Software Engineering"
+  date: '2010-05-01'
+  type: paper
+  link: https://www.billmongan.com/publication/aose2010
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:icpc2008
+  title: "Re-engineering a Reverse Engineering Portal to a Distributed SOA"
+  authors:
+    - William M. Mongan
+    - Maxim Shevertalov
+    - Spiros Mancoridis
+  publisher: "IEEE Proceedings of the 16th International Conference on Program Comprehension (ICPC)"
+  date: '2008-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/icpc2008
+  image: /images/neural-network.svg
+  tags:
+    - software engineering
+    - web
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:asee2008
+  title: "Computer Aided Instruction as a Vehicle for Problem Solving: Scratch Programming Environment in the Middle Years Classroom"
+  authors:
+    - Quincy Brown
+    - William Mongan
+    - Elaine Garbarine
+    - Dara Kusic
+    - Eli Fromm
+    - Adam Fontecchio
+  publisher: "Proceedings of the American Society for Engineering Education (ASEE) K-12 Track"
+  date: '2008-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/asee2008
+  image: /images/neural-network.svg
+  tags:
+    - cs education
+    - k-12
+  cluster: teaching-learning
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:aaai2008
+  title: "A Cyber-Infrastructure for Supporting K-12 Engineering Education through Robotics"
+  authors:
+    - William M. Mongan
+    - William C. Regli
+  publisher: "The Proceedings of the Association for the Advancement of Artificial Intelligence (AAAI) Education Track"
+  date: '2008-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/aaai2008
+  image: /images/neural-network.svg
+  tags:
+    - cs education
+    - k-12
+    - robotics
+  cluster: teaching-learning
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:iadis2007
+  title: "Dynamic Analysis of Agent Frameworks in Support of a Multiagent Systems Reference Model"
+  authors:
+    - William M. Mongan
+    - Christopher J. Dugan
+    - Robert N. Lass
+    - Andrew K. Hight
+    - Jeff Salvage
+    - William C. Regli
+    - Pragnesh J. Modi
+  publisher: "IADIS Proceedings of the International Conference Intelligent Systems and Agents (ISA)"
+  date: '2007-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/iadis2007
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:asc2006
+  title: "A Reference Model for Agent-Based Command and Control Systems"
+  authors:
+    - Christopher J. Dugan
+    - Pragnesh Jay Modi
+    - Joseph Kopena
+    - William M. Mongan
+    - William C. Regli
+    - Israel Mayk
+  publisher: "Proceedings of the 25th Army Science Conference"
+  date: '2006-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/asc2006
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+- id: manual:aamas2006
+  title: "Towards a Reference Model for Intelligent Agent Systems"
+  authors:
+    - Pragnesh Jay Modi
+    - Spiros Mancoridis
+    - William M. Mongan
+    - William Regli
+    - Israel Mayk
+  publisher: "Proceedings of the International Conference of Autonomous Agents and Multiagent Systems (AAMAS)"
+  date: '2006-01-01'
+  type: paper
+  link: https://www.billmongan.com/publication/aamas2006
+  image: /images/neural-network.svg
+  tags:
+    - agents
+    - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan
+
+
+- id: manual:pandemonium-2019-sigcse
+  title: "Post-It Pandemonium: Teaching Image Representation and Compression with an \"Unplugged\" Activity"
+  authors:
+    - William M. Mongan
+    - Jeffrey L. Popyack
+  publisher: "ACM SIGCSE 2019 Nifty Assignment"
+  date: '2019-02-01'
+  cluster: teaching-learning
+  image: https://img.youtube.com/vi/72TPC2bYaLk/hqdefault.jpg
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+    - william-m-mongan

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -17,6 +17,10 @@
   tags:
   - iot
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
 - title: 'drexelwireless/iot-processing-framework: Public Release 1.1'
   authors:
   - William M. Mongan
@@ -31,6 +35,10 @@
   tags:
   - iot
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
 - title: 'NVIZ: Unraveling Neural Networks Through Visualization'
   authors:
   - Kevin Hoffman
@@ -46,6 +54,11 @@
   - visualization
   - cosa
   cluster: explainable-ai
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - kevin-h
 - title: 'The Ursinus WebIDE: A Serverless Browser-Based Development Environment for
     Student Practice and Rapid Instructor Exercise Development'
   authors:
@@ -63,6 +76,10 @@
   - ide
   - webide
   cluster: teaching-learning
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
 - title: 'Instructional Judgment, Not Just Correctness: Evaluating AI-Generated Feedback
     on Student Mathematical Thinking'
   authors:
@@ -87,6 +104,12 @@
   - education
   - mathematics
   cluster: teaching-learning
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - michael-c
+  - matthew-l
 - title: Interactive AI Theater Presentation
   authors:
   - Levi Fritz
@@ -103,6 +126,10 @@
   - interactive
   - cosa
   cluster: teaching-learning
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
 - title: 'RAG vs. Fine-Tuning in Math Education: Developing and Validating Mentir
     AI'
   authors:
@@ -121,6 +148,13 @@
   - rag
   - cosa
   cluster: teaching-learning
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - michael-c
+  - matthew-l
+  - claire
 - title: Minute and Subject-Level Sleep Apnea Detection Using an ECG-Based Machine
     Learning Pipeline
   authors:
@@ -137,6 +171,11 @@
   - ecg
   - cosa
   cluster: biomedical-ml
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - andrei
 - title: Developing Tools for AI Explainability
   authors:
   - Michael Cummins
@@ -151,6 +190,11 @@
   - ai
   - cosa
   cluster: explainable-ai
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - michael-c
 - title: Financial Tools for the Grizzly Guide to Wealth (GGTW)
   authors:
   - Eugene Thompson
@@ -167,6 +211,10 @@
   - tools
   - cosa
   cluster: teaching-learning
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
 - title: 'UCPlaces: Campus Orientation App Using ArcGIS'
   authors:
   - Arthur Artene
@@ -182,6 +230,11 @@
   - mobile
   - cosa
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - arthur
 - title: RF IoT Security Layer
   authors:
   - Jonas Ling
@@ -196,6 +249,11 @@
   - security
   - cosa
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - jonas
 - title: 'Automated Moon Crater Detection: Exploring Algorithmic and Neural Network
     Approaches'
   authors:
@@ -211,3 +269,741 @@
   - computer vision
   - cosa
   cluster: systems-iot-cv
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+  - dylan
+- title: Predictive Analytics on Real-Time Biofeedback for Actionable Classification
+    of Activity State
+  authors:
+  - William M. Mongan
+  publisher: Drexel University
+  date: '2018-01-01'
+  id: manual:dissertation
+  type: thesis
+  link: https://www.billmongan.com/publication/dissertation
+  image: /images/ecg-trace.svg
+  tags:
+  - machine learning
+  - healthcare
+  - rfid
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: A Service-Based Web Portal for Integrated Reverse Engineering and Program
+    Comprehension
+  authors:
+  - William M. Mongan
+  publisher: Drexel University
+  date: '2008-01-01'
+  id: manual:msthesis
+  type: thesis
+  link: https://www.billmongan.com/publication/msthesis
+  image: /images/neural-network.svg
+  tags:
+  - software engineering
+  - web
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Wearable Smart Garment Devices for Passive Biomedical Monitoring
+  authors:
+  - Chelsea Amanatides
+  - Stephen Hansen
+  - Ariana S. Levitt
+  - Yuqiao Liu
+  - Patrick O-Neill
+  - Damiano Patron
+  - Robert Ross
+  - Daniel Schwartz
+  - Jesse Stover
+  - Md Abu Saleh Tajin
+  - Genevieve Dion
+  - Adam K. Fontecchio
+  - Vasil Pano
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: 'Biomedical Signal Processing: Innovation and Applications'
+  date: '2021-04-01'
+  id: doi:10.1007/978-3-030-67494-6_4
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2021
+  image: /images/ecg-trace.svg
+  tags:
+  - wearables
+  - healthcare
+  - iot
+  - rfid
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: A Methodology for Developing an Agent Systems Reference Architecture
+  authors:
+  - Duc N. Nguyen
+  - Kyle Usbeck
+  - William M. Mongan
+  - Christopher T. Cannon
+  - Robert N. Lass
+  - Jeff Salvage
+  - William C. Regli
+  - Israel Mayk
+  - Todd Urness
+  publisher: Agent-Oriented Software Engineering XI
+  date: '2011-01-01'
+  id: manual:aose2011
+  type: paper
+  link: https://www.billmongan.com/publication/aose2011
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Passive UHF RFID-based Real-Time Intravenous Fluid Level Sensor
+  authors:
+  - Md Abu Saleh Tajin
+  - Md Shakir Hossain
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: IEEE Sensors Journal
+  date: '2023-01-01'
+  id: manual:sensors2023
+  type: paper
+  link: https://www.billmongan.com/publication/sensors2023
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - healthcare
+  - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Energy-Efficient Respiratory Anomaly Detection in Premature Newborn Infants
+  authors:
+  - Ankita Paul
+  - Md. A.S. Tajin
+  - Anup Das
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: MDPI Electronics Journal - Neuromorphic Sensing and Computing Systems
+  date: '2022-03-01'
+  id: manual:electronics2022
+  type: paper
+  link: https://www.billmongan.com/publication/electronics2022
+  image: /images/ecg-trace.svg
+  tags:
+  - machine learning
+  - healthcare
+  - rfid
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: UHF RFID Channel Emulation Testbed for Wireless IoT Systems
+  authors:
+  - Md Abu Saleh Tajin
+  - Marko Jacovic
+  - Genevieve Dion
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: IEEE Access Journal
+  date: '2021-05-01'
+  id: manual:access2020
+  type: paper
+  link: https://www.billmongan.com/publication/access2020
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - iot
+  - wireless
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Passive RFID-based Diaper Moisture Sensor
+  authors:
+  - Md Abu Saleh Tajin
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: IEEE Sensors Journal
+  date: '2020-10-01'
+  id: manual:sensors2020
+  type: paper
+  link: https://www.billmongan.com/publication/sensors2020
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - healthcare
+  - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Ensemble Learning Approach via Kalman Filtering for a Passive Wearable Respiratory
+    Monitor
+  authors:
+  - Sayandeep Acharya
+  - William M. Mongan
+  - Ilhaan Rasheed
+  - Yuqiao Liu
+  - Endla Anday
+  - Genevieve Dion
+  - Adam Fontecchio
+  - Timothy Kurzweg
+  - Kapil R. Dandekar
+  publisher: IEEE Transactions on Biomedical and Health Informatics
+  date: '2019-05-01'
+  id: manual:tbhi2019
+  type: paper
+  link: https://www.billmongan.com/publication/tbhi2019
+  image: /images/ecg-trace.svg
+  tags:
+  - machine learning
+  - healthcare
+  - wearables
+  - rfid
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: On the Use of Knitted Antennas and Inductively Coupled RFID Tags for Wearable
+    Applications
+  authors:
+  - Damiano Patron
+  - William Mongan
+  - Timothy Kurzweg
+  - Adam Fontecchio
+  - Genevieve Dion
+  - Endla Anday
+  - Kapil R. Dandekar
+  publisher: IEEE Transactions on Biomedical Circuits and Systems
+  date: '2016-01-01'
+  id: manual:tbcs2016
+  type: paper
+  link: https://www.billmongan.com/publication/tbcs2016
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - wearables
+  - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Development and Specification of a Reference Architecture for Agent-Based
+    Systems
+  authors:
+  - William Regli
+  - Israel Mayk
+  - Christopher Cannon
+  - Joseph Kopena
+  - Robert Lass
+  - William M. Mongan
+  publisher: IEEE Transactions on Human Machine Systems
+  date: '2013-01-01'
+  id: manual:thms2013
+  type: paper
+  link: https://www.billmongan.com/publication/thms2013
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Development and Specification of a Reference Model for Agent-Based Systems
+  authors:
+  - William Regli
+  - Israel Mayk
+  - Christopher J. Dugan
+  - Joseph B. Kopena
+  - Robert N. Lass
+  - Pragnesh Jay Modi
+  - William M. Mongan
+  - Jeff K. Salvage
+  - Evan A. Sultanik
+  publisher: IEEE Transactions on Systems Man and Cybernetics
+  date: '2009-09-01'
+  id: manual:smc2009
+  type: paper
+  link: https://www.billmongan.com/publication/smc2009
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: An Adaptively Parameterized Algorithm Estimating Respiratory Rate from a
+    Passive Wearable RFID Smart Garment
+  authors:
+  - Robert Ross
+  - William M. Mongan
+  - Patrick O-Neill
+  - Ilhaan Rasheed
+  - Adam Fontecchio
+  - Genevieve Dion
+  - Kapil R. Dandekar
+  publisher: IEEE Conference on Computers, Software, and Applications (COMPSAC)
+  date: '2021-07-01'
+  id: manual:compsac2021
+  type: paper
+  link: https://www.billmongan.com/publication/compsac2021
+  image: /images/ecg-trace.svg
+  tags:
+  - rfid
+  - healthcare
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Channel Emulation for the Characterization of Wearable RFID Antennas
+  authors:
+  - Md Abu Saleh Tajin
+  - Marko Jacovic
+  - Xaime Rivas Rey
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: IEEE Wireless and Microwave Technology Conference (WAMICON)
+  date: '2021-04-01'
+  id: manual:wamicon2020
+  type: paper
+  link: https://www.billmongan.com/publication/wamicon2020
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - wireless
+  - wearables
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Fusion Learning on Multiple-Tag RFID Measurements for Respiratory Rate Monitoring
+  authors:
+  - Stephen Hansen
+  - Daniel Schwartz
+  - Jesse Stover
+  - Md Abu Saleh Tajin
+  - William M. Mongan
+  - Kapil R. Dandekar
+  publisher: IEEE International Conference on Bioinformatics and Biomedical Engineering
+    (BIBE)
+  date: '2020-10-01'
+  id: manual:bibe2020
+  type: paper
+  link: https://www.billmongan.com/publication/bibe2020
+  image: /images/ecg-trace.svg
+  tags:
+  - machine learning
+  - rfid
+  - healthcare
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: An Adaptive Search Algorithm for Detecting Respiratory Artifacts Using a
+    Wireless Passive Wearable Device
+  authors:
+  - Patrick O-Neill
+  - William M. Mongan
+  - Robert Ross
+  - Sayandeep Acharya
+  - Adam K. Fontecchio
+  - Kapil R. Dandekar
+  publisher: IEEE Signal Processing in Medicine and Biology
+  date: '2019-12-01'
+  id: manual:spmb2019
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2019
+  image: /images/ecg-trace.svg
+  tags:
+  - rfid
+  - healthcare
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Activity Segmentation Using Wearable Sensors for DVT/PE Risk Detection
+  authors:
+  - Austin Gentry
+  - William M. Mongan
+  - Brent Lee
+  - Owen Montgomery
+  - Kapil Dandekar
+  publisher: The First IEEE International Workshop on Integrated Smart Healthcare
+    (WISH 2019) at IEEE COMPSAC
+  date: '2019-07-01'
+  id: manual:compsac2019
+  type: paper
+  link: https://www.billmongan.com/publication/compsac2019
+  image: /images/ecg-trace.svg
+  tags:
+  - machine learning
+  - healthcare
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Data Fusion of Single-Tag RFID Measurements for Respiratory Rate Monitoring
+  authors:
+  - William M. Mongan
+  - Robert Ross
+  - Ilhaan Rasheed
+  - Yuqiao Liu
+  - Khyati Ved
+  - Endla Anday
+  - Kapil Dandekar
+  - Genevieve Dion
+  - Timothy Kurzweg
+  - Adam Fontecchio
+  publisher: IEEE Signal Processing in Medicine and Biology (SPMB)
+  date: '2017-12-01'
+  id: manual:spmb2017
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2017
+  image: /images/ecg-trace.svg
+  tags:
+  - rfid
+  - healthcare
+  - signal processing
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: On Implementing an Unconventional Infant Vital Signs Monitor with Passive
+    RFID Tags
+  authors:
+  - Shrenik A. Vora
+  - William M. Mongan
+  - Endla K. Anday
+  - Kapil R. Dandekar
+  - Genevieve Dion
+  - Adam K. Fontecchio
+  - Timothy P. Kurzweg
+  publisher: IEEE International Conference on RFID
+  date: '2017-05-01'
+  id: manual:rfid2017
+  type: paper
+  link: https://www.billmongan.com/publication/rfid2017
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - healthcare
+  - wearables
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: On the Use of Radio Frequency Identification for Continuous Biomedical Monitoring
+  authors:
+  - William Mongan
+  - Ilhaan Rasheed
+  - Khyati Ved
+  - Shrenik Vora
+  - Kapil Dandekar
+  - Genevieve Dion
+  - Timothy Kurzweg
+  - Adam Fontecchio
+  publisher: ACM/IEEE International Conference on Internet-of-Things Design and Implementation
+    (IoTDI)
+  date: '2017-04-01'
+  id: manual:iotdi2017
+  type: paper
+  link: https://www.billmongan.com/publication/iotdi2017
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - healthcare
+  - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Real-Time Detection of Apnea via Signal Processing of Time-Series Properties
+    of RFID-Based Smart Garments
+  authors:
+  - William M. Mongan
+  - Ilhaan Rasheed
+  - Khyati Ved
+  - Ariana Levitt
+  - Endla Anday
+  - Kapil Dandekar
+  - Genevieve Dion
+  - Timothy Kurzweg
+  - Adam Fontecchio
+  publisher: IEEE Signal Processing in Medicine and Biology (SPMB)
+  date: '2016-12-01'
+  id: manual:spmb2016
+  type: paper
+  link: https://www.billmongan.com/publication/spmb2016
+  image: /images/ecg-trace.svg
+  tags:
+  - rfid
+  - healthcare
+  - signal processing
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: A Multi-Disciplinary Framework for Continuous Biomedical Monitoring Using
+    Low-Power Passive RFID-based Wireless Wearable Sensors
+  authors:
+  - William Mongan
+  - Endla Anday
+  - Genevieve Dion
+  - Adam Fontecchio
+  - Tim Kurzweg
+  - Kelly Joyce
+  - Yuqiao Liu
+  - Owen Montgomery
+  - Ilhaan Rasheed
+  - Cem Sahin
+  - Shrenik Vora
+  - Kapil Dandekar
+  publisher: Proceedings of the IEEE Smart Systems Workshop
+  date: '2016-05-01'
+  id: manual:smartcomp2016
+  type: paper
+  link: https://www.billmongan.com/publication/smartcomp2016
+  image: /images/wireless-encrypted.svg
+  tags:
+  - rfid
+  - healthcare
+  - wearables
+  - iot
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Wireless Heart and Respiration Monitoring for Infants through Passive RFID
+    Tags
+  authors:
+  - Shrenik Vora
+  - William Mongan
+  - Kapil Dandekar
+  - Adam Fontecchio
+  - Tim Kurzweg
+  publisher: IEEE International Conference on Biomedical and Health Informatics (BHI)
+  date: '2016-02-01'
+  id: manual:bhi2016
+  type: paper
+  link: https://www.billmongan.com/publication/bhi2016
+  image: /images/ecg-trace.svg
+  tags:
+  - rfid
+  - healthcare
+  - wearables
+  cluster: biomedical-ml
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Developing an Agent Systems Reference Architecture
+  authors:
+  - Duc N. Nguyen
+  - Robert N. Lass
+  - Kyle Usbeck
+  - William M. Mongan
+  - Christopher T. Cannon
+  - William C. Regli
+  - Israel Mayk
+  - Todd Urness
+  publisher: Proceedings of the 11th International Workshop on Agent Oriented Software
+    Engineering
+  date: '2010-05-01'
+  id: manual:aose2010
+  type: paper
+  link: https://www.billmongan.com/publication/aose2010
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Re-engineering a Reverse Engineering Portal to a Distributed SOA
+  authors:
+  - William M. Mongan
+  - Maxim Shevertalov
+  - Spiros Mancoridis
+  publisher: IEEE Proceedings of the 16th International Conference on Program Comprehension
+    (ICPC)
+  date: '2008-01-01'
+  id: manual:icpc2008
+  type: paper
+  link: https://www.billmongan.com/publication/icpc2008
+  image: /images/neural-network.svg
+  tags:
+  - software engineering
+  - web
+  cluster: systems-iot-cv
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: 'Computer Aided Instruction as a Vehicle for Problem Solving: Scratch Programming
+    Environment in the Middle Years Classroom'
+  authors:
+  - Quincy Brown
+  - William Mongan
+  - Elaine Garbarine
+  - Dara Kusic
+  - Eli Fromm
+  - Adam Fontecchio
+  publisher: Proceedings of the American Society for Engineering Education (ASEE)
+    K-12 Track
+  date: '2008-01-01'
+  id: manual:asee2008
+  type: paper
+  link: https://www.billmongan.com/publication/asee2008
+  image: /images/neural-network.svg
+  tags:
+  - cs education
+  - k-12
+  cluster: teaching-learning
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: A Cyber-Infrastructure for Supporting K-12 Engineering Education through
+    Robotics
+  authors:
+  - William M. Mongan
+  - William C. Regli
+  publisher: The Proceedings of the Association for the Advancement of Artificial
+    Intelligence (AAAI) Education Track
+  date: '2008-01-01'
+  id: manual:aaai2008
+  type: paper
+  link: https://www.billmongan.com/publication/aaai2008
+  image: /images/neural-network.svg
+  tags:
+  - cs education
+  - k-12
+  - robotics
+  cluster: teaching-learning
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Dynamic Analysis of Agent Frameworks in Support of a Multiagent Systems Reference
+    Model
+  authors:
+  - William M. Mongan
+  - Christopher J. Dugan
+  - Robert N. Lass
+  - Andrew K. Hight
+  - Jeff Salvage
+  - William C. Regli
+  - Pragnesh J. Modi
+  publisher: IADIS Proceedings of the International Conference Intelligent Systems
+    and Agents (ISA)
+  date: '2007-01-01'
+  id: manual:iadis2007
+  type: paper
+  link: https://www.billmongan.com/publication/iadis2007
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: A Reference Model for Agent-Based Command and Control Systems
+  authors:
+  - Christopher J. Dugan
+  - Pragnesh Jay Modi
+  - Joseph Kopena
+  - William M. Mongan
+  - William C. Regli
+  - Israel Mayk
+  publisher: Proceedings of the 25th Army Science Conference
+  date: '2006-01-01'
+  id: manual:asc2006
+  type: paper
+  link: https://www.billmongan.com/publication/asc2006
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- title: Towards a Reference Model for Intelligent Agent Systems
+  authors:
+  - Pragnesh Jay Modi
+  - Spiros Mancoridis
+  - William M. Mongan
+  - William Regli
+  - Israel Mayk
+  publisher: Proceedings of the International Conference of Autonomous Agents and
+    Multiagent Systems (AAMAS)
+  date: '2006-01-01'
+  id: manual:aamas2006
+  type: paper
+  link: https://www.billmongan.com/publication/aamas2006
+  image: /images/neural-network.svg
+  tags:
+  - agents
+  - software engineering
+  cluster: systems-agents
+  research-visible: false
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan
+- id: manual:pandemonium-2019-sigcse
+  title: 'Post-It Pandemonium: Teaching Image Representation and Compression with
+    an "Unplugged" Activity'
+  authors:
+  - William M. Mongan
+  - Jeffrey L. Popyack
+  publisher: ACM SIGCSE 2019 Nifty Assignment
+  date: '2019-02-01'
+  cluster: teaching-learning
+  image: https://img.youtube.com/vi/72TPC2bYaLk/hqdefault.jpg
+  research-visible: true
+  projects-visible: true
+  team-contributors:
+  - william-m-mongan

--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -26,6 +26,18 @@
   link: https://michaelcummins1.github.io/nviz/
   description: "NVIZ is an interactive, no-code neural network visualizer that lets you upload data, define a network architecture, train a model, and explore its behavior through Sankey diagram visualizations — all in the browser. Designed to improve AI literacy through hands-on experimentation, NVIZ makes explainable AI (XAI) accessible without any programming knowledge. Developed by Ursinus students Kevin Hoffman and Michael Cummins. Source code available on <a href=\"https://github.com/michaelcummins1/nviz\">GitHub</a>."
 
+- title: "Ursinus WebIDE"
+  type: featured
+  image: https://www.billmongan.com/Ursinus-WebIDE/images/graphicsScreenshot.png
+  link: https://www.billmongan.com/Ursinus-WebIDE/
+  description: "A serverless, browser-based development environment for student practice and rapid instructor exercise development, supporting multiple languages with no setup required. Developed with Christopher Tralie at Ursinus College."
+
+- title: "Grizzly Guide to Wealth (GGTW) — Student Presentation"
+  type: featured
+  image: /images/candlestick-chart.svg
+  link: https://digitalcommons.ursinus.edu/math_comp_pres/9/
+  description: "Financial literacy and planning tools developed for the Grizzly Guide to Wealth platform, presented at Ursinus CoSA 2025. Developed by Eugene Thompson and George Psaradakis."
+
 - title: IoT Sensor Framework
   type: featured
   image: http://www.billmongan.com/files/media/software-iotframework/simbabyandpregnancy.jpg

--- a/_includes/member-feature.html
+++ b/_includes/member-feature.html
@@ -29,9 +29,9 @@
       <img src="{{ member.image | relative_url }}"
         alt="Portrait of {{ member.title }}, {{ role_label }}, HMIS Lab."
         loading="lazy"
-        onerror="this.src='{{ '/images/placeholder.svg' | relative_url }}'; this.onerror = null;" />
+        onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror = null;" />
       {%- else -%}
-      <img src="{{ '/images/placeholder.svg' | relative_url }}"
+      <img src="{{ '/images/placeholder-avatar.svg' | relative_url }}"
         alt="Portrait placeholder for {{ member.title }}, {{ role_label }}, HMIS Lab."
         loading="lazy" />
       {%- endif -%}

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -1,6 +1,6 @@
 <a {% if include.link %}href="{{ include.link | relative_url }}"{% endif %} class="portrait" data-mini="{{ include.mini | default: false }}">
 
-  {%- assign placeholder = include.placeholder | default: "images/placeholder.svg" | relative_url -%}
+  {%- assign placeholder = include.placeholder | default: "images/placeholder-avatar.svg" | relative_url -%}
 
   <span class="portrait_image">
     {%- if include.image -%}

--- a/_includes/project-entry.html
+++ b/_includes/project-entry.html
@@ -1,26 +1,31 @@
 {%- comment -%}
   Single completed project rendered as a bibliography line.
-  Thumbnail left, title + description + tags + link right.
-  Carries `card` so the existing card-search JS can find it
-  if a search component is ever added to this page.
+  Thumbnail left, title + description + tags right.
+
+  If the project has associated research IDs, a "See publications" button
+  is shown that opens a slide-out sidebar listing those publications.
 
   Parameter
     project   The project object from site.data.projects.
 {%- endcomment -%}
 
 {%- assign project = include.project -%}
+{%- assign project_slug = project.title | slugify -%}
+
+{%- assign all_papers = site.data['research-output'] -%}
+{%- assign project_papers = "" | split: "" -%}
+{%- for paper_id in project.research -%}
+  {%- assign matching = all_papers | where: "id", paper_id -%}
+  {%- assign project_papers = project_papers | concat: matching -%}
+{%- endfor -%}
+{%- assign has_research = false -%}
+{%- if project.research and project_papers.size > 0 -%}{%- assign has_research = true -%}{%- endif -%}
+{%- assign has_contributors = false -%}
+{%- if project['team-contributors'] and project['team-contributors'].size > 0 -%}{%- assign has_contributors = true -%}{%- endif -%}
+{%- assign has_sidebar = false -%}
+{%- if has_research or has_contributors -%}{%- assign has_sidebar = true -%}{%- endif -%}
 
 <article class="card project-entry" data-type="{{ project.type }}">
-  {%- if project.link -%}
-  <a class="project-entry_thumbnail" href="{{ project.link }}" tabindex="-1" aria-hidden="true">
-    {%- if project.image -%}
-    <img src="{{ project.image | relative_url }}" alt="" loading="lazy"
-      onerror="this.src='{{ '/images/placeholder.svg' | relative_url }}'; this.onerror = null;" />
-    {%- else -%}
-    <img src="{{ '/images/placeholder.svg' | relative_url }}" alt="" loading="lazy" />
-    {%- endif -%}
-  </a>
-  {%- else -%}
   <div class="project-entry_thumbnail">
     {%- if project.image -%}
     <img src="{{ project.image | relative_url }}" alt="" loading="lazy"
@@ -29,16 +34,9 @@
     <img src="{{ '/images/placeholder.svg' | relative_url }}" alt="" loading="lazy" />
     {%- endif -%}
   </div>
-  {%- endif -%}
 
   <div class="project-entry_text">
-    <h3 class="project-entry_title">
-      {%- if project.link -%}
-      <a href="{{ project.link }}">{{ project.title }}</a>
-      {%- else -%}
-      {{ project.title }}
-      {%- endif -%}
-    </h3>
+    <h3 class="project-entry_title">{{ project.title }}</h3>
 
     {%- if project.description -%}
     <p class="project-entry_description">{{ project.description }}</p>
@@ -49,5 +47,19 @@
       {%- include tags.html tags=project.tags repo=project.repo -%}
     </div>
     {%- endif -%}
+
+    {%- if has_sidebar -%}
+    <button class="project-feature_link project-title-btn"
+            aria-controls="sidebar-{{ project_slug }}"
+            aria-expanded="false"
+            aria-haspopup="dialog">
+      {%- if has_research -%}See team and publications{%- else -%}Meet the team{%- endif -%}
+      <span aria-hidden="true">→</span>
+    </button>
+    {%- endif -%}
   </div>
+
+  {%- if has_sidebar -%}
+  {%- include project-sidebar.html project=project slug=project_slug -%}
+  {%- endif -%}
 </article>

--- a/_includes/project-feature.html
+++ b/_includes/project-feature.html
@@ -2,9 +2,8 @@
   Project feature row. Image one side, text article-shaped on the other.
   Alternates by `side` parameter. Used for active projects on /projects/.
 
-  Distinct from the home Spread: no seam-overlap, smaller scale, more
-  compact vertical rhythm so a sequence of 5 rows reads at a sensible
-  page length.
+  If the project has associated research IDs, the title becomes a button
+  that opens a slide-out sidebar listing those publications.
 
   Parameters
     project   Required. The project object from site.data.projects.
@@ -13,35 +12,35 @@
 
 {%- assign project = include.project -%}
 {%- assign side = include.side | default: "image-left" -%}
+{%- assign project_slug = project.title | slugify -%}
 
-{%- assign type_label = "Project" -%}
-{%- if project.type == "research" -%}{%- assign type_label = "Research Project" -%}{%- endif -%}
+{%- assign type_label = "Research Project" -%}
 {%- if project.type == "software" -%}{%- assign type_label = "Software" -%}{%- endif -%}
-{%- if project.type == "student" -%}{%- assign type_label = "Student Work" -%}{%- endif -%}
+
+{%- assign all_papers = site.data['research-output'] -%}
+{%- assign project_papers = "" | split: "" -%}
+{%- for paper_id in project.research -%}
+  {%- assign matching = all_papers | where: "id", paper_id -%}
+  {%- assign project_papers = project_papers | concat: matching -%}
+{%- endfor -%}
+{%- assign has_research = false -%}
+{%- if project.research and project_papers.size > 0 -%}{%- assign has_research = true -%}{%- endif -%}
+{%- assign has_contributors = false -%}
+{%- if project['team-contributors'] and project['team-contributors'].size > 0 -%}{%- assign has_contributors = true -%}{%- endif -%}
+{%- assign has_sidebar = false -%}
+{%- if has_research or has_contributors -%}{%- assign has_sidebar = true -%}{%- endif -%}
 
 <article class="project-feature project-feature--{{ side }}" data-type="{{ project.type }}">
   <div class="project-feature_inner">
     {%- if project.image -%}
     <div class="project-feature_image">
-      {%- if project.link -%}
-      <a href="{{ project.link }}" tabindex="-1" aria-hidden="true">
-        <img src="{{ project.image | relative_url }}" alt="" loading="lazy" />
-      </a>
-      {%- else -%}
       <img src="{{ project.image | relative_url }}" alt="" loading="lazy" />
-      {%- endif -%}
     </div>
     {%- endif -%}
 
     <div class="project-feature_text">
       <span class="project-feature_eyebrow">{{ type_label }}</span>
-      <h3 class="project-feature_title">
-        {%- if project.link -%}
-        <a href="{{ project.link }}">{{ project.title }}</a>
-        {%- else -%}
-        {{ project.title }}
-        {%- endif -%}
-      </h3>
+      <h3 class="project-feature_title">{{ project.title }}</h3>
 
       {%- if project.description -%}
       <p class="project-feature_description">{{ project.description }}</p>
@@ -53,12 +52,19 @@
       </div>
       {%- endif -%}
 
-      {%- if project.link -%}
-      <a href="{{ project.link }}" class="project-feature_link">
-        Visit project
+      {%- if has_sidebar -%}
+      <button class="project-feature_link project-title-btn"
+              aria-controls="sidebar-{{ project_slug }}"
+              aria-expanded="false"
+              aria-haspopup="dialog">
+        {%- if has_research -%}See team and publications{%- else -%}Meet the team{%- endif -%}
         <span aria-hidden="true">→</span>
-      </a>
+      </button>
       {%- endif -%}
     </div>
   </div>
+
+  {%- if has_sidebar -%}
+  {%- include project-sidebar.html project=project slug=project_slug -%}
+  {%- endif -%}
 </article>

--- a/_includes/project-sidebar.html
+++ b/_includes/project-sidebar.html
@@ -1,0 +1,105 @@
+{%- comment -%}
+  Sidebar panel for a project's associated research publications and team.
+  Rendered inline inside project-feature and project-entry articles.
+  Opened by clicking the project title button; closed via the X button,
+  the backdrop overlay, or the Escape key (handled by project-sidebar.js).
+
+  Parameters
+    project   The project object from site.data.projects.
+    slug      Pre-computed slugify of project.title.
+{%- endcomment -%}
+
+{%- assign project = include.project -%}
+{%- assign slug = include.slug -%}
+{%- assign all_papers = site.data['research-output'] -%}
+
+{%- assign project_papers = "" | split: "" -%}
+{%- for paper_id in project.research -%}
+  {%- assign matching = all_papers | where: "id", paper_id -%}
+  {%- assign project_papers = project_papers | concat: matching -%}
+{%- endfor -%}
+{%- assign project_papers = project_papers | where_exp: "paper", "paper['projects-visible'] != false" -%}
+{%- assign project_papers = project_papers | sort: "date" | reverse -%}
+
+{%- assign has_contributors = false -%}
+{%- if project['team-contributors'] and project['team-contributors'].size > 0 -%}
+  {%- assign has_contributors = true -%}
+{%- endif -%}
+
+{%- if project_papers.size > 0 or has_contributors -%}
+<aside class="project-sidebar"
+       id="sidebar-{{ slug }}"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="sidebar-title-{{ slug }}"
+       aria-hidden="true">
+  <div class="project-sidebar_inner">
+    <div class="project-sidebar_header">
+      <h2 class="project-sidebar_title" id="sidebar-title-{{ slug }}">{{ project.title }}</h2>
+      <button class="project-sidebar_close" aria-label="Close research panel" data-sidebar-close>
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+          <path d="M3 3L15 15M15 3L3 15" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+
+    {%- if has_contributors -%}
+    <div class="project-sidebar_team">
+      <p class="project-sidebar_section-label">Team</p>
+      <ul class="project-sidebar_contributors" role="list">
+        {%- for contrib_slug in project['team-contributors'] -%}
+        {%- assign member = nil -%}
+        {%- for m in site.members -%}
+          {%- assign m_slug = m.path | split: "/" | last | remove: ".md" -%}
+          {%- if m_slug == contrib_slug -%}{%- assign member = m -%}{%- endif -%}
+        {%- endfor -%}
+        {%- if member -%}
+        <li class="project-sidebar_contributor">
+          <a href="{{ member.url | relative_url }}" class="project-sidebar_contributor-link">
+            {%- if member.image -%}
+            <img src="{{ member.image | relative_url }}" alt="{{ member.title }}"
+                 class="project-sidebar_contributor-avatar"
+                 onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror=null;" />
+            {%- else -%}
+            <span class="project-sidebar_contributor-avatar project-sidebar_contributor-avatar--placeholder" aria-hidden="true">
+              {{ member.title | slice: 0 }}
+            </span>
+            {%- endif -%}
+            <span class="project-sidebar_contributor-name">{{ member.title }}</span>
+          </a>
+        </li>
+        {%- endif -%}
+        {%- endfor -%}
+      </ul>
+    </div>
+    {%- endif -%}
+
+    {%- if project_papers.size > 0 -%}
+    <p class="project-sidebar_count">
+      {{ project_papers.size }} publication{%- if project_papers.size != 1 -%}s{%- endif -%}
+    </p>
+    <ul class="project-sidebar_papers" role="list">
+      {%- for paper in project_papers -%}
+      {%- assign year = paper.date | date: "%Y" -%}
+      {%- assign authors = paper.authors | join: ", " -%}
+      <li class="project-sidebar_paper">
+        <h3 class="project-sidebar_paper-title">
+          {%- if paper.link -%}
+          <a href="{{ paper.link }}" target="_blank" rel="noopener noreferrer">{{ paper.title }}</a>
+          {%- else -%}
+          {{ paper.title }}
+          {%- endif -%}
+        </h3>
+        <p class="project-sidebar_paper-meta">
+          {%- if authors != "" -%}{{ authors }}{%- endif -%}
+          {%- if authors != "" and paper.publisher -%}<span class="project-sidebar_dot" aria-hidden="true"> · </span>{%- endif -%}
+          {%- if paper.publisher -%}<em>{{ paper.publisher }}</em>{%- endif -%}
+          {%- if paper.date -%}<span class="project-sidebar_dot" aria-hidden="true"> · </span>{{ year }}{%- endif -%}
+        </p>
+      </li>
+      {%- endfor -%}
+    </ul>
+    {%- endif -%}
+  </div>
+</aside>
+{%- endif -%}

--- a/_includes/research-bibliography.html
+++ b/_includes/research-bibliography.html
@@ -12,7 +12,8 @@
   _data/research-output.yml (so this page reflects it now).
 {%- endcomment -%}
 
-{%- assign papers = site.data.research-output -%}
+{%- assign papers = site.data['research-output'] -%}
+{%- assign papers = papers | where_exp: "paper", "paper['research-visible'] != false" -%}
 {%- assign papers = papers | sort: "date" | reverse -%}
 
 {%- comment -%} Cluster definitions. Order = display order. {%- endcomment -%}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -19,6 +19,7 @@
 </script>
 
 <!-- site-wide javascript scripts -->
+<script src="{{ 'js/project-sidebar.js' | relative_url }}" defer></script>
 <script src="{{ 'js/anchors.js' | relative_url }}"></script>
 <script src="{{ 'js/fetch-tags.js' | relative_url }}"></script>
 <script src="{{ 'js/card-search.js' | relative_url }}"></script>

--- a/_includes/spread.html
+++ b/_includes/spread.html
@@ -39,13 +39,7 @@
       {%- if include.eyebrow -%}
       <span class="spread_eyebrow">{{ include.eyebrow }}</span>
       {%- endif -%}
-      <h2 class="spread_title">
-        {%- if include.link -%}
-        <a href="{{ include.link | relative_url }}">{{ include.title }}</a>
-        {%- else -%}
-        {{ include.title }}
-        {%- endif -%}
-      </h2>
+      <h2 class="spread_title">{{ include.title }}</h2>
       <p class="spread_body">{{ include.body }}</p>
       {%- if include.link -%}
       <a href="{{ include.link | relative_url }}" class="spread_link">

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -27,6 +27,7 @@
 <link href="{{ 'css/paper-link.css' | relative_url }}" rel="stylesheet" />
 <link href="{{ 'css/pi-welcome.css' | relative_url }}" rel="stylesheet" />
 <link href="{{ 'css/portrait.css' | relative_url }}" rel="stylesheet" />
+<link href="{{ 'css/project-sidebar.css' | relative_url }}" rel="stylesheet" />
 <link href="{{ 'css/projects.css' | relative_url }}" rel="stylesheet" />
 <link href="{{ 'css/research.css' | relative_url }}" rel="stylesheet" />
 <link href="{{ 'css/resources.css' | relative_url }}" rel="stylesheet" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     <main id="main" tabindex="-1">
       {% include content.html content=content %}
     </main>
+    <div class="project-sidebar-overlay" aria-hidden="true"></div>
     {% include footer.html %}
   </body>
 </html>

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -14,26 +14,87 @@ layout: default
 
     {% include member-feature.html member=page %}
 
-    {%- assign names = "" | split: ',' -%}
-    {%- if page.search.first -%}
-    {%- assign names = names | concat: page.search -%}
-    {%- elsif page.search -%}
-    {%- assign names = names | push: page.search -%}
-    {%- elsif page.title -%}
-    {%- assign names = names | push: page.title -%}
+    {%- assign member_slug = page.path | split: "/" | last | remove: ".md" -%}
+
+    {%- comment -%} Collect projects this member contributed to {%- endcomment -%}
+    {%- assign member_projects = "" | split: "" -%}
+    {%- for project in site.data.projects -%}
+      {%- if project['team-contributors'] contains member_slug -%}
+        {%- assign member_projects = member_projects | push: project -%}
+      {%- endif -%}
+    {%- endfor -%}
+
+    {%- comment -%} Collect publications this member contributed to {%- endcomment -%}
+    {%- assign all_papers = site.data['research-output'] -%}
+    {%- assign member_papers = "" | split: "" -%}
+    {%- for paper in all_papers -%}
+      {%- if paper['team-contributors'] contains member_slug -%}
+        {%- if paper['research-visible'] != false or paper['projects-visible'] != false -%}
+          {%- assign member_papers = member_papers | push: paper -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- assign member_papers = member_papers | sort: "date" | reverse -%}
+
+    {%- if member_projects.size > 0 or member_papers.size > 0 -%}
+    <div class="member-page_work">
+
+      {%- if member_projects.size > 0 -%}
+      <div class="member-page_section">
+        <h2 class="member-page_section-title">Projects</h2>
+        <ul class="member-page_list" role="list">
+          {%- for project in member_projects -%}
+          <li class="member-page_list-item">
+            <div class="member-page_item-header">
+              <span class="member-page_item-title">{{ project.title }}</span>
+              <span class="member-page_item-badge member-page_item-badge--{{ project.status }}">
+                {%- if project.status == "completed" -%}Completed{%- else -%}Active{%- endif -%}
+              </span>
+            </div>
+            {%- if project.description -%}
+            <p class="member-page_item-desc">{{ project.description }}</p>
+            {%- endif -%}
+          </li>
+          {%- endfor -%}
+        </ul>
+      </div>
+      {%- endif -%}
+
+      {%- if member_papers.size > 0 -%}
+      <div class="member-page_section">
+        <h2 class="member-page_section-title">Publications</h2>
+        <ul class="member-page_list" role="list">
+          {%- for paper in member_papers -%}
+          {%- assign year = paper.date | date: "%Y" -%}
+          {%- assign authors = paper.authors | join: ", " -%}
+          <li class="member-page_list-item">
+            <div class="member-page_item-header">
+              <span class="member-page_item-title">
+                {%- if paper.link -%}
+                <a href="{{ paper.link }}" target="_blank" rel="noopener noreferrer">{{ paper.title }}</a>
+                {%- else -%}
+                {{ paper.title }}
+                {%- endif -%}
+              </span>
+              {%- if year != "" -%}
+              <span class="member-page_item-badge member-page_item-badge--year">{{ year }}</span>
+              {%- endif -%}
+            </div>
+            {%- if authors != "" or paper.publisher -%}
+            <p class="member-page_item-desc">
+              {%- if authors != "" -%}{{ authors }}{%- endif -%}
+              {%- if authors != "" and paper.publisher -%}<span class="member-page_dot" aria-hidden="true"> · </span>{%- endif -%}
+              {%- if paper.publisher -%}<em>{{ paper.publisher }}</em>{%- endif -%}
+            </p>
+            {%- endif -%}
+          </li>
+          {%- endfor -%}
+        </ul>
+      </div>
+      {%- endif -%}
+
+    </div>
     {%- endif -%}
-
-    {%- capture search -%}
-    {%- for name in names -%}"{{ name }}" {% endfor -%}
-    {%- endcapture -%}
-
-    {%- assign search = search | strip | prepend: "/research/?search=" -%}
-
-    <a class="member-page_papers" href="{{ search | relative_url }}">
-      <i class="fas fa-book-open" aria-hidden="true"></i>
-      <span>{{ page.title }}'s papers</span>
-      <span aria-hidden="true">→</span>
-    </a>
 
   </div>
 </div>

--- a/_members/eugene-t.md
+++ b/_members/eugene-t.md
@@ -1,0 +1,8 @@
+---
+title: Eugene T.
+search:
+  - Eugene
+role: undergrad
+group: alum
+---
+

--- a/_members/izayah-c.md
+++ b/_members/izayah-c.md
@@ -1,0 +1,8 @@
+---
+title: Izayah C.
+search:
+  - Izayah
+role: undergrad
+group: current
+---
+

--- a/_members/levi-f.md
+++ b/_members/levi-f.md
@@ -1,0 +1,8 @@
+---
+title: Levi F.
+search:
+  - Levi
+role: undergrad
+group: current
+---
+

--- a/css/member-feature.scss
+++ b/css/member-feature.scss
@@ -152,8 +152,8 @@
 }
 
 // ── Single member page wrapper ─────────────────────────────────────────────
-// Used by _layouts/member.html. Wraps the member-feature block + a small
-// "papers by this member" link.
+// Used by _layouts/member.html. Wraps the member-feature block plus
+// project and publication sections for this member.
 
 .member-page {
   position: relative;
@@ -170,42 +170,141 @@
   margin: 0 auto;
 }
 
-.member-page_papers {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
+// ── Work sections (projects + publications) ──────────────────────────────────
+
+.member-page_work {
   margin-top: 56px;
   padding-top: 32px;
   border-top: 1px solid $border-medium;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.member-page_section-title {
   font-family: $sans;
-  font-size: 0.95rem;
+  font-size: 0.72rem;
   font-weight: $semi-bold;
-  color: $primary;
-  text-decoration: none;
-  width: 100%;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: $text-secondary;
+  margin: 0 0 20px 0;
+  padding: 0;
 
-  i {
-    font-size: 0.85rem;
+  &::after {
+    display: none;
+  }
+}
+
+.member-page_list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.member-page_list-item {
+  padding: 18px 0;
+  border-bottom: 1px solid $border-medium;
+
+  &:first-child {
+    border-top: 1px solid $border-medium;
+  }
+}
+
+.member-page_item-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.member-page_item-title {
+  font-family: $serif;
+  font-optical-sizing: auto;
+  font-size: 0.98rem;
+  font-weight: $medium;
+  line-height: 1.45;
+  color: $text-dark;
+  margin: 0 0 4px 0;
+  padding: 0;
+  display: block;
+
+  &::after {
+    display: none;
   }
 
-  span:last-child {
-    transition: transform $fast;
-    display: inline-block;
-  }
+  a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color $fast, border-color $fast;
 
-  &:hover {
-    color: #f84b4b;
+    &:hover {
+      color: $primary;
+      border-bottom-color: rgba($primary, 0.4);
+    }
 
-    span:last-child {
-      transform: translateX(4px);
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba($primary, 0.30);
+      border-radius: 2px;
     }
   }
+}
 
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba($primary, 0.30);
-    border-radius: 2px;
+.member-page_item-badge {
+  font-family: $sans;
+  font-size: 0.68rem;
+  font-weight: $semi-bold;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: $radius-full;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &--active {
+    background: rgba($primary, 0.1);
+    color: $primary;
   }
+
+  &--completed {
+    background: $bg-raised;
+    color: $text-secondary;
+  }
+
+  &--year {
+    background: $bg-raised;
+    color: $text-secondary;
+  }
+}
+
+.member-page_item-desc {
+  font-family: $sans;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: $text-secondary;
+  margin: 4px 0 0 0;
+}
+
+.member-page_item-meta {
+  font-family: $sans;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: $text-secondary;
+  margin: 0;
+
+  em {
+    font-style: normal;
+  }
+}
+
+.member-page_dot {
+  color: $border-strong;
 }
 
 // ── Mobile ─────────────────────────────────────────────────────────────────
@@ -230,7 +329,7 @@
     padding: 48px 24px 64px;
   }
 
-  .member-page_papers {
+  .member-page_work {
     margin-top: 40px;
     padding-top: 24px;
   }
@@ -239,10 +338,6 @@
 // ── Reduced motion ─────────────────────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
   .member-feature_portrait:hover img {
-    transform: none;
-  }
-
-  .member-page_papers:hover span:last-child {
     transform: none;
   }
 }

--- a/css/project-sidebar.scss
+++ b/css/project-sidebar.scss
@@ -1,0 +1,326 @@
+---
+---
+
+@import "variables";
+@import "mixins";
+
+// ── Project sidebar overlay ──────────────────────────────────────────────────
+
+.project-sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(41, 37, 36, 0.45);
+  z-index: 200;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity $fast, visibility $fast;
+
+  &.is-open {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
+// ── Project sidebar panel ────────────────────────────────────────────────────
+
+.project-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(480px, 100vw);
+  height: 100dvh;
+  background: $bg-surface;
+  z-index: 210;
+  box-shadow: -4px 0 32px rgba(41, 37, 36, 0.14);
+  overflow-y: auto;
+  visibility: hidden;
+  transform: translateX(100%);
+  transition: transform $slow, visibility $slow;
+
+  &.is-open {
+    visibility: visible;
+    transform: translateX(0);
+  }
+}
+
+.project-sidebar_inner {
+  padding: 36px 32px 56px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  box-sizing: border-box;
+}
+
+// ── Header ───────────────────────────────────────────────────────────────────
+
+.project-sidebar_header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 6px;
+}
+
+.project-sidebar_title {
+  font-family: $serif;
+  font-optical-sizing: auto;
+  font-size: 1.2rem;
+  font-weight: $semi-bold;
+  line-height: 1.35;
+  color: $text-dark;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  text-align: left;
+
+  &::after {
+    display: none;
+  }
+}
+
+.project-sidebar_close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: transparent;
+  border: 1.5px solid $border-medium;
+  border-radius: $radius-full;
+  color: $text-secondary;
+  cursor: pointer;
+  transition: color $fast, border-color $fast, background $fast;
+  margin-top: 1px;
+
+  &:hover {
+    color: $text-dark;
+    border-color: $border-strong;
+    background: $bg-raised;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba($primary, 0.30);
+  }
+}
+
+// ── Section label ────────────────────────────────────────────────────────────
+
+.project-sidebar_section-label {
+  font-family: $sans;
+  font-size: 0.72rem;
+  font-weight: $semi-bold;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: $text-secondary;
+  margin: 0 0 14px 0;
+}
+
+// ── Team contributors ─────────────────────────────────────────────────────────
+
+.project-sidebar_team {
+  margin-bottom: 32px;
+}
+
+.project-sidebar_contributors {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.project-sidebar_contributor {
+  display: flex;
+}
+
+.project-sidebar_contributor-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: $text-dark;
+  transition: color $fast;
+
+  &:hover {
+    color: $primary;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba($primary, 0.30);
+    border-radius: 4px;
+  }
+}
+
+.project-sidebar_contributor-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: $radius-full;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: $bg-raised;
+}
+
+.project-sidebar_contributor-avatar--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: $bg-raised;
+  color: $text-secondary;
+  font-family: $sans;
+  font-size: 0.85rem;
+  font-weight: $semi-bold;
+  text-transform: uppercase;
+}
+
+.project-sidebar_contributor-name {
+  font-family: $sans;
+  font-size: 0.88rem;
+  font-weight: $medium;
+  line-height: 1.3;
+}
+
+// ── Count label ──────────────────────────────────────────────────────────────
+
+.project-sidebar_count {
+  font-family: $sans;
+  font-size: 0.72rem;
+  font-weight: $semi-bold;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: $text-secondary;
+  margin: 0 0 24px 0;
+}
+
+// ── Paper list ───────────────────────────────────────────────────────────────
+
+.project-sidebar_papers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.project-sidebar_paper {
+  padding: 20px 0;
+  border-bottom: 1px solid $border-medium;
+
+  &:first-child {
+    border-top: 1px solid $border-medium;
+  }
+}
+
+.project-sidebar_paper-title {
+  font-family: $serif;
+  font-optical-sizing: auto;
+  font-size: 0.98rem;
+  font-weight: $medium;
+  line-height: 1.45;
+  color: $text-dark;
+  margin: 0 0 6px 0;
+  padding: 0;
+  text-align: left;
+
+  &::after {
+    display: none;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color $fast, border-color $fast;
+
+    &:hover {
+      color: $primary;
+      border-bottom-color: rgba($primary, 0.4);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba($primary, 0.30);
+      border-radius: 2px;
+    }
+  }
+}
+
+.project-sidebar_paper-meta {
+  font-family: $sans;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: $text-secondary;
+  margin: 0;
+
+  em {
+    font-style: normal;
+  }
+}
+
+.project-sidebar_dot {
+  color: $border-strong;
+}
+
+// ── Title trigger button (looks like text, opens sidebar) ────────────────────
+
+.project-title-btn {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  display: block;
+  width: 100%;
+  transition: color $fast;
+
+  &:hover {
+    color: $primary;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba($primary, 0.30);
+    border-radius: 2px;
+  }
+}
+
+// When used as the "See publications →" CTA inside project-feature, inherit
+// the link styling already defined there.
+.project-feature_link.project-title-btn {
+  width: auto;
+  display: inline-flex;
+}
+
+// ── Prevent body scroll when sidebar is open ─────────────────────────────────
+
+body.sidebar-open {
+  overflow: hidden;
+}
+
+// ── Mobile ───────────────────────────────────────────────────────────────────
+
+@media (max-width: 500px) {
+  .project-sidebar {
+    width: 100vw;
+  }
+
+  .project-sidebar_inner {
+    padding: 24px 20px 48px;
+  }
+}
+
+// ── Reduced motion ────────────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .project-sidebar,
+  .project-sidebar-overlay {
+    transition: none;
+  }
+}

--- a/images/fire-hydrant.svg
+++ b/images/fire-hydrant.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+
+  <!-- ── Ground ── -->
+  <rect x="0" y="100" width="200" height="20" fill="#c8bfb8"/>
+  <rect x="0" y="98" width="200" height="4" fill="#b0a89e"/>
+
+  <!-- ══ FIRETRUCK (left side, facing right) ══ -->
+
+  <!-- chassis / body -->
+  <rect x="8" y="58" width="118" height="42" rx="4" fill="#c0281a"/>
+
+  <!-- cab front -->
+  <rect x="100" y="46" width="30" height="54" rx="4" fill="#c0281a"/>
+
+  <!-- windshield -->
+  <rect x="103" y="50" width="22" height="18" rx="2" fill="#b8ddf0"/>
+
+  <!-- cab door window -->
+  <rect x="82" y="62" width="18" height="14" rx="2" fill="#b8ddf0"/>
+
+  <!-- body side panel accent -->
+  <rect x="10" y="66" width="70" height="6" rx="1" fill="#a82315"/>
+  <rect x="10" y="78" width="70" height="6" rx="1" fill="#a82315"/>
+
+  <!-- ladder rack on top -->
+  <rect x="14" y="50" width="84" height="9" rx="2" fill="#8b1f14"/>
+  <!-- ladder rungs -->
+  <line x1="28" y1="50" x2="28" y2="59" stroke="#c0281a" stroke-width="1.5"/>
+  <line x1="42" y1="50" x2="42" y2="59" stroke="#c0281a" stroke-width="1.5"/>
+  <line x1="56" y1="50" x2="56" y2="59" stroke="#c0281a" stroke-width="1.5"/>
+  <line x1="70" y1="50" x2="70" y2="59" stroke="#c0281a" stroke-width="1.5"/>
+  <line x1="84" y1="50" x2="84" y2="59" stroke="#c0281a" stroke-width="1.5"/>
+
+  <!-- light bar -->
+  <rect x="104" y="44" width="24" height="5" rx="2" fill="#831b10"/>
+  <rect x="107" y="44" width="5" height="5" rx="1" fill="#f87171"/>
+  <rect x="119" y="44" width="5" height="5" rx="1" fill="#60a5fa"/>
+
+  <!-- front bumper -->
+  <rect x="128" y="80" width="8" height="14" rx="2" fill="#8b1f14"/>
+
+  <!-- hose compartment door -->
+  <rect x="12" y="68" width="14" height="24" rx="2" fill="#8b1f14"/>
+
+  <!-- wheels -->
+  <circle cx="32" cy="100" r="13" fill="#3a3633"/>
+  <circle cx="32" cy="100" r="8" fill="#6b6560"/>
+  <circle cx="32" cy="100" r="3" fill="#3a3633"/>
+
+  <circle cx="110" cy="100" r="13" fill="#3a3633"/>
+  <circle cx="110" cy="100" r="8" fill="#6b6560"/>
+  <circle cx="110" cy="100" r="3" fill="#3a3633"/>
+
+  <!-- ══ FIRE HYDRANT (right, smaller) ══ -->
+
+  <!-- base flange -->
+  <rect x="157" y="90" width="26" height="8" rx="2" fill="#a82315"/>
+
+  <!-- lower body -->
+  <rect x="161" y="74" width="18" height="17" rx="4" fill="#c0281a"/>
+
+  <!-- upper body -->
+  <rect x="163" y="64" width="14" height="13" rx="3" fill="#c0281a"/>
+
+  <!-- bonnet collar -->
+  <rect x="162" y="59" width="16" height="7" rx="3" fill="#a82315"/>
+
+  <!-- bonnet dome -->
+  <ellipse cx="170" cy="59" rx="9" ry="4" fill="#a82315"/>
+  <ellipse cx="170" cy="57" rx="6" ry="3" fill="#c0281a"/>
+
+  <!-- top nut -->
+  <rect x="167" y="53" width="6" height="5" rx="1" fill="#831b10"/>
+
+  <!-- left outlet -->
+  <rect x="153" y="77" width="9" height="6" rx="2" fill="#c0281a"/>
+  <circle cx="153" cy="80" r="2.5" fill="#831b10"/>
+
+  <!-- right outlet -->
+  <rect x="178" y="77" width="9" height="6" rx="2" fill="#c0281a"/>
+  <circle cx="187" cy="80" r="2.5" fill="#831b10"/>
+
+  <!-- center bolt detail -->
+  <rect x="167" y="80" width="6" height="6" rx="1" fill="#831b10"/>
+
+</svg>

--- a/images/placeholder-avatar.svg
+++ b/images/placeholder-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="32" fill="#e8e5e2"/>
+  <circle cx="32" cy="24" r="11" fill="#b8b0a8"/>
+  <path d="M8 56c0-13.255 10.745-24 24-24s24 10.745 24 24" fill="#b8b0a8"/>
+</svg>

--- a/js/project-sidebar.js
+++ b/js/project-sidebar.js
@@ -1,0 +1,82 @@
+(function () {
+  "use strict";
+
+  var overlay = document.querySelector(".project-sidebar-overlay");
+  if (!overlay) return;
+
+  function openSidebar(sidebar, trigger) {
+    sidebar.classList.add("is-open");
+    sidebar.removeAttribute("aria-hidden");
+    overlay.classList.add("is-open");
+    document.body.classList.add("sidebar-open");
+    if (trigger) trigger.setAttribute("aria-expanded", "true");
+    var closeBtn = sidebar.querySelector("[data-sidebar-close]");
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeSidebar(sidebar, trigger) {
+    sidebar.classList.remove("is-open");
+    sidebar.setAttribute("aria-hidden", "true");
+    overlay.classList.remove("is-open");
+    document.body.classList.remove("sidebar-open");
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", "false");
+      trigger.focus();
+    }
+  }
+
+  function getOpenSidebar() {
+    return document.querySelector(".project-sidebar.is-open");
+  }
+
+  function getTriggerForSidebar(sidebar) {
+    // There may be two triggers per project (title + "See publications" CTA).
+    // Return the first one that was clicked (aria-expanded="true").
+    var id = sidebar.id;
+    var expanded = document.querySelector(
+      '.project-title-btn[aria-controls="' + id + '"][aria-expanded="true"]'
+    );
+    if (expanded) return expanded;
+    return document.querySelector('.project-title-btn[aria-controls="' + id + '"]');
+  }
+
+  document.addEventListener("click", function (e) {
+    // Open via any title trigger button.
+    var trigger = e.target.closest(".project-title-btn");
+    if (trigger) {
+      var sidebarId = trigger.getAttribute("aria-controls");
+      var sidebar = document.getElementById(sidebarId);
+      if (sidebar) {
+        // Close any already-open sidebar first.
+        var current = getOpenSidebar();
+        if (current && current !== sidebar) {
+          closeSidebar(current, getTriggerForSidebar(current));
+        }
+        openSidebar(sidebar, trigger);
+      }
+      return;
+    }
+
+    // Close via the X button inside the sidebar.
+    var closeBtn = e.target.closest("[data-sidebar-close]");
+    if (closeBtn) {
+      var sidebar = closeBtn.closest(".project-sidebar");
+      if (sidebar) closeSidebar(sidebar, getTriggerForSidebar(sidebar));
+      return;
+    }
+
+    // Close via overlay click.
+    if (e.target === overlay) {
+      var open = getOpenSidebar();
+      if (open) closeSidebar(open, getTriggerForSidebar(open));
+    }
+  });
+
+  // Close on Escape.
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      var open = getOpenSidebar();
+      if (open) closeSidebar(open, getTriggerForSidebar(open));
+    }
+  });
+})();


### PR DESCRIPTION
## Summary

- **Project sidebar**: new slide-out panel on project cards showing team contributors (avatars + linked names) and associated publications. Fixed member lookup to use path-derived slug instead of URL construction (members build as `.html`, not directories).
- **Member detail pages**: replaced the old "View papers" search link with inline Projects and Publications sections driven by `team-contributors` tags in the YAML data. Both sections use identical markup and now render with the correct warm page background — fixed a specificity bug where `body section:not(.hero):nth-child(even)` (0,2,2) was beating `.member-page_section { background: transparent }` (0,1,0) by switching inner sections from `<section>` to `<div>`.
- **Data tagging**: all 19 projects and all 43 research entries tagged with `team-contributors` arrays; merged RFID Antenna State Selection + RF Localization projects; synchronized `research-output.yml` from input via yaml.safe_load/dump to avoid indent-mismatch corruption.
- **New content**: Pixel Pandemonium project (YouTube thumbnail, SIGCSE 2019 research entry), Emergency Response project (custom firetruck+hydrant SVG), `public safety` tag on Wireless Emergency Communications, three new member files (eugene-t, levi-f, izayah-c), circular avatar placeholder SVG.

## Test plan

- [ ] Visit a project card and click "See team and publications" — sidebar should slide in with contributor avatars and paper list
- [ ] Click a contributor name in the sidebar — should navigate to their member page
- [ ] Visit `/members/william-m-mongan/` — Projects and Publications sections should both render with the same warm background and identical typography
- [ ] Visit a student member page (e.g. `/members/michael-c/`) — should show only projects/publications they are tagged in
- [ ] Visit `/projects/` — Pixel Pandemonium and Emergency Response should appear with their thumbnails
- [ ] Confirm placeholder avatar appears for members without a photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)