### PR TITLE
Address Copilot feedback: remove dead CSS selectors and add new-tab a…

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -55,7 +55,8 @@
     {%- endif -%}
 
     {%- if paper.link -%}
-    <a class="research-entry_link" href="{{ paper.link }}" target="_blank" rel="noopener noreferrer">
+    <a class="research-entry_link" href="{{ paper.link }}" target="_blank" rel="noopener noreferrer"
+       aria-label="View the Publication (opens in new tab)">
       View the Publication <span aria-hidden="true">→</span>
     </a>
     {%- endif -%}

--- a/css/research.scss
+++ b/css/research.scss
@@ -218,11 +218,6 @@
     &:hover img {
       transform: scale(1.04);
     }
-
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px rgba($primary, 0.30);
-    }
   }
 
   .research-entry_text {
@@ -246,21 +241,6 @@
     text-transform: none;
     letter-spacing: -0.2px;
 
-    a {
-      color: inherit;
-      text-decoration: none;
-      transition: color $fast;
-
-      &:hover {
-        color: $primary;
-      }
-
-      &:focus-visible {
-        outline: none;
-        box-shadow: 0 0 0 3px rgba($primary, 0.30);
-        border-radius: 2px;
-      }
-    }
   }
 
   .research-entry_authors {


### PR DESCRIPTION
…ria-label

Remove .research-entry_thumbnail:focus-visible and .research-entry_title a rules that became dead code when the thumbnail/title were de-linked. Add aria-label to the "View the Publication" external link to inform keyboard/screen-reader users it opens in a new tab.