### PR TITLE
Add linked lab-member avatar row to research entries

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -40,6 +40,34 @@
       {%- endif -%}
     </p>
 
+    {%- if paper['team-contributors'] and paper['team-contributors'].size > 0 -%}
+    <ul class="research-entry_contributors" role="list" aria-label="Lab contributors">
+      {%- for contrib_slug in paper['team-contributors'] -%}
+      {%- assign member = nil -%}
+      {%- for m in site.members -%}
+        {%- assign m_slug = m.path | split: "/" | last | remove: ".md" -%}
+        {%- if m_slug == contrib_slug -%}{%- assign member = m -%}{%- endif -%}
+      {%- endfor -%}
+      {%- if member -%}
+      <li class="research-entry_contributor">
+        <a href="{{ member.url | relative_url }}" class="research-entry_contributor-link"
+           aria-label="{{ member.title }}">
+          {%- if member.image -%}
+          <img src="{{ member.image | relative_url }}" alt="{{ member.title }}"
+               class="research-entry_contributor-avatar"
+               onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror=null;" />
+          {%- else -%}
+          <span class="research-entry_contributor-avatar research-entry_contributor-avatar--placeholder" aria-hidden="true">
+            {{ member.title | slice: 0 }}
+          </span>
+          {%- endif -%}
+        </a>
+      </li>
+      {%- endif -%}
+      {%- endfor -%}
+    </ul>
+    {%- endif -%}
+
     {%- if paper.tags or paper.repo -%}
     <div class="research-entry_tags">
       {%- include tags.html tags=paper.tags repo=paper.repo -%}

--- a/css/research.scss
+++ b/css/research.scss
@@ -270,6 +270,58 @@
     color: $text-secondary;
   }
 
+  .research-entry_contributors {
+    list-style: none;
+    margin: 10px 0 0 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .research-entry_contributor {
+    display: flex;
+  }
+
+  .research-entry_contributor-link {
+    display: block;
+    border-radius: $radius-full;
+    transition: opacity $fast, box-shadow $fast;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba($primary, 0.30);
+    }
+  }
+
+  .research-entry_contributor-avatar {
+    display: block;
+    width: 28px;
+    height: 28px;
+    border-radius: $radius-full;
+    object-fit: cover;
+    background: $bg-raised;
+  }
+
+  .research-entry_contributor-avatar--placeholder {
+    width: 28px;
+    height: 28px;
+    border-radius: $radius-full;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: $bg-raised;
+    color: $text-secondary;
+    font-family: $sans;
+    font-size: 0.75rem;
+    font-weight: $semi-bold;
+    text-transform: uppercase;
+  }
+
   .research-entry_tags {
     margin: 0 0 12px 0;
 


### PR DESCRIPTION
Renders a horizontal row of 28px circular avatars between the venue line and tags for each paper's team-contributors. Each avatar links to the member's page, uses their photo if available, and falls back to an initial-letter placeholder. Names are carried in aria-label for screen readers.