### PR TITLE
Show contributor names under avatars; use silhouette placeholder

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -50,17 +50,11 @@
       {%- endfor -%}
       {%- if member -%}
       <li class="research-entry_contributor">
-        <a href="{{ member.url | relative_url }}" class="research-entry_contributor-link"
-           aria-label="{{ member.title }}">
-          {%- if member.image -%}
+        <a href="{{ member.url | relative_url }}" class="research-entry_contributor-link">
           <img src="{{ member.image | relative_url }}" alt="{{ member.title }}"
                class="research-entry_contributor-avatar"
                onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror=null;" />
-          {%- else -%}
-          <span class="research-entry_contributor-avatar research-entry_contributor-avatar--placeholder" aria-hidden="true">
-            {{ member.title | slice: 0 }}
-          </span>
-          {%- endif -%}
+          <span class="research-entry_contributor-name">{{ member.title }}</span>
         </a>
       </li>
       {%- endif -%}

--- a/css/research.scss
+++ b/css/research.scss
@@ -284,42 +284,45 @@
   }
 
   .research-entry_contributor-link {
-    display: block;
-    border-radius: $radius-full;
-    transition: opacity $fast, box-shadow $fast;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+    color: $text-secondary;
+    transition: color $fast, opacity $fast;
 
     &:hover {
-      opacity: 0.8;
+      color: $primary;
+      opacity: 0.85;
     }
 
     &:focus-visible {
       outline: none;
       box-shadow: 0 0 0 3px rgba($primary, 0.30);
+      border-radius: $radius-sm;
     }
   }
 
   .research-entry_contributor-avatar {
     display: block;
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     border-radius: $radius-full;
     object-fit: cover;
     background: $bg-raised;
   }
 
-  .research-entry_contributor-avatar--placeholder {
-    width: 28px;
-    height: 28px;
-    border-radius: $radius-full;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: $bg-raised;
-    color: $text-secondary;
+  .research-entry_contributor-name {
     font-family: $sans;
-    font-size: 0.75rem;
-    font-weight: $semi-bold;
-    text-transform: uppercase;
+    font-size: 0.68rem;
+    font-weight: $medium;
+    line-height: 1.2;
+    text-align: center;
+    max-width: 52px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .research-entry_tags {


### PR DESCRIPTION
- Display member.title in small text below each avatar circle
- Replace initial-letter placeholder with placeholder-avatar.svg via the existing onerror fallback (removes the placeholder span variant)
- Resize avatars to 32px; make link a column flexbox to stack avatar and name; truncate long names to keep the row compact