### PR TITLE
Fix avatar alignment: separate avatars and names as grid siblings

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -41,7 +41,7 @@
     </p>
 
     {%- if paper['team-contributors'] and paper['team-contributors'].size > 0 -%}
-    <ul class="research-entry_contributors" role="list" aria-label="Lab contributors">
+    <div class="research-entry_contributors">
       {%- for contrib_slug in paper['team-contributors'] -%}
       {%- assign member = nil -%}
       {%- for m in site.members -%}
@@ -49,22 +49,21 @@
         {%- if m_slug == contrib_slug -%}{%- assign member = m -%}{%- endif -%}
       {%- endfor -%}
       {%- if member -%}
-      <li class="research-entry_contributor">
-        <a href="{{ member.url | relative_url }}" class="research-entry_contributor-link">
-          {%- if member.image -%}
-          <img src="{{ member.image | relative_url }}" alt="" loading="lazy"
-               class="research-entry_contributor-avatar"
-               onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror=null;" />
-          {%- else -%}
-          <img src="{{ '/images/placeholder-avatar.svg' | relative_url }}" alt="" loading="lazy"
-               class="research-entry_contributor-avatar" />
-          {%- endif -%}
-          <span class="research-entry_contributor-name">{{ member.title }}</span>
-        </a>
-      </li>
+      <a href="{{ member.url | relative_url }}" class="research-entry_contributor-link"
+         aria-label="{{ member.title }}">
+        {%- if member.image -%}
+        <img src="{{ member.image | relative_url }}" alt="" loading="lazy"
+             class="research-entry_contributor-avatar"
+             onerror="this.src='{{ '/images/placeholder-avatar.svg' | relative_url }}'; this.onerror=null;" />
+        {%- else -%}
+        <img src="{{ '/images/placeholder-avatar.svg' | relative_url }}" alt="" loading="lazy"
+             class="research-entry_contributor-avatar" />
+        {%- endif -%}
+      </a>
+      <span class="research-entry_contributor-name" aria-hidden="true">{{ member.title }}</span>
       {%- endif -%}
       {%- endfor -%}
-    </ul>
+    </div>
     {%- endif -%}
 
     {%- if paper.tags or paper.repo -%}

--- a/css/research.scss
+++ b/css/research.scss
@@ -270,35 +270,35 @@
     color: $text-secondary;
   }
 
+  // Avatar links (row 1) and name spans (row 2) are direct siblings so
+  // grid-auto-flow:column places every avatar in the same explicit row,
+  // guaranteeing their tops are co-planar regardless of name line count.
   .research-entry_contributors {
-    list-style: none;
     margin: 10px 0 0 0;
-    padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, 44px);
-    gap: 8px 6px;
+    grid-auto-flow: column;
+    grid-template-rows: 32px auto;
+    grid-auto-columns: 44px;
+    column-gap: 6px;
+    row-gap: 4px;
     justify-content: start;
-    align-items: start;
   }
 
   .research-entry_contributor-link {
-    display: grid;
-    grid-template-rows: 32px auto;
-    justify-items: center;
-    row-gap: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-decoration: none;
-    color: $text-secondary;
-    transition: color $fast, opacity $fast;
+    border-radius: $radius-full;
+    transition: opacity $fast;
 
     &:hover {
-      color: $primary;
-      opacity: 0.85;
+      opacity: 0.75;
     }
 
     &:focus-visible {
       outline: none;
       box-shadow: 0 0 0 3px rgba($primary, 0.30);
-      border-radius: $radius-sm;
     }
   }
 
@@ -309,7 +309,6 @@
     border-radius: $radius-full;
     object-fit: cover;
     background: $bg-raised;
-    align-self: start;
   }
 
   .research-entry_contributor-name {
@@ -318,7 +317,7 @@
     font-weight: $medium;
     line-height: 1.25;
     text-align: center;
-    max-width: 44px;
+    color: $text-secondary;
     overflow: hidden;
     display: block;
     display: -webkit-box;


### PR DESCRIPTION
Previous approach wrapped avatar+name inside a single chip element, so grid/flex alignment shifted the whole chip — meaning a 2-line name pushed the avatar for that chip to a different row than 1-line chips.

New approach: avatar <a> and name <span> are direct siblings inside a grid container with grid-auto-flow:column and grid-template-rows:32px auto. The auto-placement algorithm fills col-1 row-1 (avatar), col-1 row-2 (name), col-2 row-1 (avatar), col-2 row-2 (name)... so every avatar lands in the same explicit 32px row by spec — no alignment dependency on name length.