### PR TITLE
Address Copilot feedback on contributor grid structure

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -41,7 +41,7 @@
     </p>
 
     {%- if paper['team-contributors'] and paper['team-contributors'].size > 0 -%}
-    <div class="research-entry_contributors">
+    <div class="research-entry_contributors" aria-label="Lab contributors">
       {%- for contrib_slug in paper['team-contributors'] -%}
       {%- assign member = nil -%}
       {%- for m in site.members -%}
@@ -60,7 +60,8 @@
              class="research-entry_contributor-avatar" />
         {%- endif -%}
       </a>
-      <span class="research-entry_contributor-name" aria-hidden="true">{{ member.title }}</span>
+      <a href="{{ member.url | relative_url }}" class="research-entry_contributor-name"
+         tabindex="-1" aria-hidden="true">{{ member.title }}</a>
       {%- endif -%}
       {%- endfor -%}
     </div>

--- a/css/research.scss
+++ b/css/research.scss
@@ -282,6 +282,7 @@
     column-gap: 6px;
     row-gap: 4px;
     justify-content: start;
+    overflow-x: auto;
   }
 
   .research-entry_contributor-link {
@@ -318,6 +319,7 @@
     line-height: 1.25;
     text-align: center;
     color: $text-secondary;
+    text-decoration: none;
     overflow: hidden;
     display: block;
     display: -webkit-box;
@@ -326,6 +328,10 @@
     word-break: normal;
     overflow-wrap: normal;
     align-self: start;
+
+    &:hover {
+      color: $primary;
+    }
   }
 
   .research-entry_tags {


### PR DESCRIPTION
- Make contributor name a link (<a tabindex="-1" aria-hidden="true">) to the same member page as the avatar; tabindex=-1 keeps it out of the keyboard tab order since the avatar link already covers that destination.
- Restore aria-label="Lab contributors" on the container div so assistive tech retains the group label that was removed with the <ul>.
- Add overflow-x:auto so the non-wrapping column grid scrolls horizontally on narrow viewports rather than overflowing the page (wrapping is skipped because it would break the 2-row grid row assignment that keeps avatars co-planar).