### PR TITLE
Add role=group so aria-label is announced on contributors container

### DIFF
--- a/_includes/research-entry.html
+++ b/_includes/research-entry.html
@@ -41,7 +41,7 @@
     </p>
 
     {%- if paper['team-contributors'] and paper['team-contributors'].size > 0 -%}
-    <div class="research-entry_contributors" aria-label="Lab contributors">
+    <div class="research-entry_contributors" role="group" aria-label="Lab contributors">
       {%- for contrib_slug in paper['team-contributors'] -%}
       {%- assign member = nil -%}
       {%- for m in site.members -%}


### PR DESCRIPTION
A plain <div> has no implicit ARIA role, so aria-label is silently ignored by assistive tech. role=group gives the container a semantic grouping role that exposes the label without requiring child listitem roles or structural changes.