### PR TITLE
Update Mold D. status from current to alum

### DIFF
--- a/_members/mold.md
+++ b/_members/mold.md
@@ -3,6 +3,6 @@ title: Mold D.
 search:
   - Mold
 role: undergrad
-group: current
+group: alum
 ---
 


### PR DESCRIPTION
## Summary
Update member status to reflect graduation or transition from current undergraduate to alumni.

## Changes
- Changed group status for Mold D. from `current` to `alum` in member profile

## Details
This change updates the member's group classification in the members directory, moving them from the current members list to the alumni list.

https://claude.ai/code/session_018u2E7cGQz9MvJUyBi7SRBe