### PR TITLE
Move 10 undergraduate members from current to alumni

### DIFF
--- a/_members/andrei.md
+++ b/_members/andrei.md
@@ -3,6 +3,5 @@ title: Andrei B.
 search:
   - Andrei
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/emily.md
+++ b/_members/emily.md
@@ -3,6 +3,5 @@ title: Emily M.
 search:
   - Emily
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/jaheim.md
+++ b/_members/jaheim.md
@@ -3,6 +3,5 @@ title: Jaheim O.
 search:
   - jaheim
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/jonathan.md
+++ b/_members/jonathan.md
@@ -3,6 +3,5 @@ title: Jonathan P.
 search:
   - jonathan
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/josh-b.md
+++ b/_members/josh-b.md
@@ -3,6 +3,5 @@ title: Josh B.
 search:
   - JoshB
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/levi-f.md
+++ b/_members/levi-f.md
@@ -3,6 +3,5 @@ title: Levi F.
 search:
   - Levi
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/owen.md
+++ b/_members/owen.md
@@ -3,6 +3,5 @@ title: Owen F.
 search:
   - Owen
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/tim.md
+++ b/_members/tim.md
@@ -3,6 +3,5 @@ title: Tim J.
 search:
   - Tim
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/tyler.md
+++ b/_members/tyler.md
@@ -3,6 +3,5 @@ title: Tyler H.
 search:
   - tyler
 role: undergrad
-group: current
+group: alum
 ---
-

--- a/_members/will.md
+++ b/_members/will.md
@@ -3,6 +3,5 @@ title: Will P.
 search:
   - Will
 role: undergrad
-group: current
+group: alum
 ---
-


### PR DESCRIPTION
## Summary
This PR updates the member roster by transitioning 10 undergraduate members from the current group to alumni status.

## Changes
- Updated group classification from `current` to `alum` for the following members:
  - Andrei B.
  - Emily M.
  - Jaheim O.
  - Jonathan P.
  - Josh B.
  - Levi F.
  - Owen F.
  - Tim J.
  - Tyler H.
  - Will P.

## Details
Each member's profile file was updated to change the `group` field in the front matter from `current` to `alum`, reflecting their transition out of the active undergraduate program. Trailing whitespace was also removed from these files.

https://claude.ai/code/session_01QiDEYKeJ3EeAahpo1WidKY